### PR TITLE
Enable oauth on hub api as well

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.61.0
+version: 0.62.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -27,6 +27,10 @@ metadata:
   name: hub-api-ingress
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress }}
+    {{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+    {{- end }}
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -23,6 +23,10 @@ metadata:
   name: hub-frontend-demo-ingress
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress }}
+    {{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+    {{- end }}
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"


### PR DESCRIPTION
## Pull Request Description

### Title: Enable OAuth on Hub API as well

### Motivation and Context:
This pull request introduces OAuth2 proxy support to the Hub API and Hub Frontend Demo services. By enabling OAuth2 proxy, we enhance the security of our services by enforcing authentication and ensuring that only authorized users can access them. 

### Changes:
1. **Chart Version Increment:**
   - Updated the chart version from `0.61.0` to `0.62.0` in `charts/hub/Chart.yaml` to reflect the new changes and maintain semantic versioning.

2. **Hub API Ingress Annotations:**
   - Added conditional annotations for OAuth2 proxy support in `charts/hub/templates/kerberos-hub/hub-api.yaml`. 
   - When `kerberoshub.oauth2Proxy.enabled` is set to true, the following annotations are added:
     - `nginx.ingress.kubernetes.io/auth-url`: Points to the OAuth2 authentication URL.
     - `nginx.ingress.kubernetes.io/auth-signin`: Redirects to the OAuth2 sign-in URL.

3. **Hub Frontend Demo Ingress Annotations:**
   - Added similar conditional annotations for OAuth2 proxy support in `charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml`.
   - These annotations ensure that the frontend demo also requires OAuth2 authentication.

### Benefits:
- **Enhanced Security:** By integrating OAuth2 proxy, we add an additional layer of security, ensuring that only authenticated users can access the Hub API and Frontend Demo.
- **Consistency:** Both the Hub API and Frontend Demo now have consistent authentication mechanisms, improving the overall security posture of our project.

By making these changes, we ensure that our services are more secure and aligned with best practices for authentication and authorization.