### PR TITLE
upgrade to 0.63.0 - missing ingress

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.62.0
+version: 0.63.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -97,6 +97,36 @@ spec:
     {{- end }}
   {{ end }}
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oauth2-proxy
+  namespace: kube-system
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress }}
+    {{- if eq .Values.ingress "nginx" }}
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{- end }}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: "{{ .Values.kerberoshub.api.url }}"
+      http:
+        paths:
+          - path: /oauth2
+            pathType: Prefix
+            backend:
+              service:
+                name: oauth2-proxy
+                port:
+                  number: 4180
+  tls:
+    - hosts:
+        - "{{ .Values.kerberoshub.api.url }}"
+      secretName: 
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -64,6 +64,36 @@ spec:
               servicePort: 80
   {{ end }}
 ---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oauth2-proxy
+  namespace: kube-system
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress }}
+    {{- if eq .Values.ingress "nginx" }}
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    {{- end }}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: "{{ .Values.kerberoshub.frontend.demoUrl }}"
+      http:
+        paths:
+          - path: /oauth2
+            pathType: Prefix
+            backend:
+              service:
+                name: oauth2-proxy
+                port:
+                  number: 4180
+  tls:
+    - hosts:
+        - "{{ .Values.kerberoshub.frontend.demoUrl }}"
+      secretName: 
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:


### PR DESCRIPTION
### Pull Request Description: Upgrade to 0.63.0 - Missing Ingress

#### Motivation

The primary motivation behind this upgrade is to address the missing Ingress configurations that are crucial for routing external traffic to the appropriate services within our Kubernetes cluster. By upgrading to version 0.63.0, we ensure that our chart includes these necessary configurations, which were previously absent.

#### Changes Made

1. **Chart Version Update:**
   - Bumped the chart version from `0.62.0` to `0.63.0` in `charts/hub/Chart.yaml` to reflect the new changes.

2. **Ingress Configuration for Hub API:**
   - Added an Ingress resource in `charts/hub/templates/kerberos-hub/hub-api.yaml` to handle external traffic for the OAuth2 proxy. This includes annotations for NGINX and TLS settings, ensuring secure communication.

3. **Ingress Configuration for Hub Frontend Demo:**
   - Similarly, added an Ingress resource in `charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml` for the frontend demo URL. This also includes necessary annotations and TLS settings for secure and proper routing.

#### Why It Improves the Project

- **Enhanced Accessibility:** The addition of Ingress resources improves the accessibility of our services by properly routing external traffic to the desired endpoints.
- **Security:** By including TLS settings and annotations for Let's Encrypt, we ensure secure communication channels, enhancing the security posture of our application.
- **Consistency:** Aligns with best practices for Kubernetes deployments by explicitly defining how external traffic should be managed, leading to a more robust and reliable deployment strategy.

Overall, this upgrade addresses a critical gap in our deployment configuration, ensuring that our services are accessible, secure, and properly routed within the Kubernetes environment.