### PR TITLE
update to 0.64.0 + change ingress names

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.63.0
+version: 0.64.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -100,7 +100,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: oauth2-proxy
+  name: oauth2-proxy-api
   namespace: kube-system
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress }}

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -67,7 +67,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: oauth2-proxy
+  name: oauth2-proxy-frontend-demo
   namespace: kube-system
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress }}

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -108,7 +108,7 @@ spec:
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: oauth2-proxy
+  name: oauth2-proxy-frontend
   namespace: kube-system
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress }}


### PR DESCRIPTION
### Pull Request Description

#### Title: Update to 0.64.0 + Change Ingress Names

#### Motivation and Improvement:

1. **Version Update**:
   - **Chart Version**: Incremented the chart version from `0.63.0` to `0.64.0` in `charts/hub/Chart.yaml`. This follows Semantic Versioning and reflects the updates and improvements made in this release. Keeping the version updated ensures clarity in tracking changes and deploying the correct version.

2. **Ingress Name Changes**:
   - **Purpose**: The ingress names have been made more descriptive to avoid confusion and potential conflicts.
   - **Changes**:
     - In `charts/hub/templates/kerberos-hub/hub-api.yaml`: Changed the ingress name from `oauth2-proxy` to `oauth2-proxy-api`.
     - In `charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml`: Changed the ingress name from `oauth2-proxy` to `oauth2-proxy-frontend-demo`.
     - In `charts/hub/templates/kerberos-hub/hub-frontend.yaml`: Changed the ingress name from `oauth2-proxy` to `oauth2-proxy-frontend`.
   - **Benefits**: These changes make the ingress names more specific to their respective components, improving readability and maintainability of the code. It also helps in better management and debugging of ingress resources in the Kubernetes environment.

Overall, these changes enhance the project's version management and improve the clarity and specificity of ingress resource naming, contributing to a more robust and maintainable codebase.