### PR TITLE
oauth for api + upgrade to 0.65.0

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.64.0
+version: 0.65.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -23,24 +23,16 @@ metadata:
   name: hub-frontend-demo-ingress
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress }}
-    {{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
-    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
-    {{- end }}
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     {{- end }}
 spec:
-
   {{- with .Values.kerberoshub.frontend.demoTls }}
   tls:
     {{- toYaml . | nindent 8 }}
   {{- end }}
-
-
-  
   {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
   rules:
     - host: "{{ .Values.kerberoshub.frontend.demoUrl }}"
@@ -63,36 +55,6 @@ spec:
               serviceName: hub-frontend-demo-svc
               servicePort: 80
   {{ end }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: oauth2-proxy-frontend-demo
-  namespace: kube-system
-  annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress }}
-    {{- if eq .Values.ingress "nginx" }}
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    kubernetes.io/tls-acme: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    {{- end }}
-spec:
-  ingressClassName: nginx
-  rules:
-    - host: "{{ .Values.kerberoshub.frontend.demoUrl }}"
-      http:
-        paths:
-          - path: /oauth2
-            pathType: Prefix
-            backend:
-              service:
-                name: oauth2-proxy
-                port:
-                  number: 4180
-  tls:
-    - hosts:
-        - "{{ .Values.kerberoshub.frontend.demoUrl }}"
-      secretName: 
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -23,10 +23,6 @@ metadata:
   name: hub-frontend-ingress
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress }}
-    {{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
-    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
-    {{- end }}
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -103,38 +99,6 @@ spec:
               servicePort: 80
     {{- end }}
   {{- end }}
-{{- if eq .Values.kerberoshub.oauth2Proxy.enabled true }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: oauth2-proxy-frontend
-  namespace: kube-system
-  annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress }}
-    {{- if eq .Values.ingress "nginx" }}
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    kubernetes.io/tls-acme: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    {{- end }}
-spec:
-  ingressClassName: nginx
-  rules:
-    - host: "{{ .Values.kerberoshub.frontend.url }}"
-      http:
-        paths:
-          - path: /oauth2
-            pathType: Prefix
-            backend:
-              service:
-                name: oauth2-proxy
-                port:
-                  number: 4180
-  tls:
-    - hosts:
-        - "{{ .Values.kerberoshub.frontend.url }}"
-      secretName: oauth2-proxy-tls
-{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
### Pull Request Title: oauth for api + upgrade to 0.65.0

### Description:

#### Motivation:
The primary motivation for this pull request is to upgrade the project to version 0.65.0 and streamline the OAuth2 proxy configuration for the API. By doing so, we aim to enhance the security and maintainability of the project.

#### Changes:
1. **Version Upgrade:**
   - Updated the chart version from 0.64.0 to 0.65.0 in `charts/hub/Chart.yaml`.
   
2. **Simplified OAuth2 Configuration:**
   - Removed redundant OAuth2 proxy ingress configurations from `charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml` and `charts/hub/templates/kerberos-hub/hub-frontend.yaml`.
   - Eliminated unnecessary annotations related to OAuth2 proxy in the frontend ingress configurations.

#### Benefits:
- **Security Enhancement:** Streamlining the OAuth2 proxy configuration reduces potential misconfigurations and security vulnerabilities.
- **Maintainability:** Simplifying the ingress configurations makes the codebase easier to understand and maintain.
- **Consistency:** Ensuring consistent and minimal configuration across different environments.

Overall, these changes contribute to a more secure, maintainable, and consistent project setup.