### PR TITLE
add cors to ingress + upgrade to 0.66.0

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.65.0
+version: 0.66.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -30,6 +30,7 @@ metadata:
     {{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
     nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+    nginx.ingress.kubernetes.io/enable-cors: true
     {{- end }}
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
### Description

This pull request includes the following changes:
1. Upgrades the chart version to 0.66.0.
2. Adds CORS (Cross-Origin Resource Sharing) support to the Nginx ingress annotations.

### Motivation

1. **Chart Version Upgrade**: Upgrading to version 0.66.0 ensures that we are using the latest features and bug fixes available in the chart, improving overall stability and performance.
2. **Enable CORS**: Adding CORS support to the ingress allows our API to be accessed from different origins, which is essential for modern web applications that often fetch resources from different domains. This improves the flexibility and usability of our API.

By incorporating these changes, we enhance the project's robustness and compatibility with various web applications, ensuring a better developer and user experience.