### PR TITLE
convert to string + upgrade to 0.67.0

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.66.0
+version: 0.67.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -30,7 +30,7 @@ metadata:
     {{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
     nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
-    nginx.ingress.kubernetes.io/enable-cors: true
+    nginx.ingress.kubernetes.io/enable-cors: "true"
     {{- end }}
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
## Description

### Motivation

The primary motivation for this pull request is to ensure that all values in the Helm chart are strings where required. This can help prevent potential issues with type mismatches in the configuration. Additionally, upgrading the chart version to 0.67.0 ensures that users are aware of this change and can benefit from any other improvements or fixes included in this new version.

### Changes

1. **Version Upgrade:**
   - Updated the chart version in `charts/hub/Chart.yaml` from `0.66.0` to `0.67.0`.

2. **Configuration Update:**
   - Converted the value of `nginx.ingress.kubernetes.io/enable-cors` in `charts/hub/templates/kerberos-hub/hub-api.yaml` from a boolean to a string (`true` to `"true"`).

### Benefits

- **Type Consistency:** Ensures that all configurations comply with expected types, reducing the risk of runtime errors or misconfigurations.
- **Version Clarity:** The version bump to 0.67.0 clearly communicates to users that there have been changes and they should update their deployments accordingly.

This pull request improves the overall stability and maintainability of the project by enforcing consistent data types and keeping the versioning clear and up-to-date.