### PR TITLE
try out --skip-auth-preflight=true

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.69.0
+version: 0.70.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -110,10 +110,6 @@ metadata:
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     nginx.ingress.kubernetes.io/enable-cors: "true"
-    nginx.ingress.kubernetes.io/server-snippet: |
-      if ($request_method = "OPTIONS") {
-        return 200;
-      }
     {{- end }}
 spec:
   ingressClassName: nginx

--- a/charts/hub/templates/kerberos-hub/hub-oauth2-proxy.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-oauth2-proxy.yaml
@@ -22,6 +22,7 @@ spec:
             - --email-domain=*
             - --upstream=file:///dev/null
             - --http-address=0.0.0.0:4180
+            - --skip-auth-preflight=true
           env:
             - name: OAUTH2_PROXY_CLIENT_ID
               value: "{{ .Values.kerberoshub.oauth2Proxy.github.clientId }}"


### PR DESCRIPTION
### Pull Request Description

#### Motivation
The current setup for handling preflight CORS requests in our Kubernetes ingress controller involves using a server snippet to return a 200 status code for OPTIONS requests. This approach has been functional, but it adds complexity and potential maintenance overhead to our configuration.

#### Changes Made
1. **Chart Version Update**: Incremented the chart version from 0.69.0 to 0.70.0 to reflect these changes.
2. **Ingress Configuration**:
    - Removed the server snippet from `hub-api.yaml` that was handling OPTIONS requests.
3. **OAuth2 Proxy Configuration**:
    - Added the `--skip-auth-preflight=true` flag to the `hub-oauth2-proxy.yaml` configuration.

#### Benefits
- **Simplified Configuration**: By removing the server snippet, the ingress configuration is simplified, making it easier to maintain and understand.
- **Improved Performance**: Leveraging the `--skip-auth-preflight` flag in OAuth2 Proxy allows for more efficient handling of preflight requests, potentially improving performance and reducing latency.
- **Enhanced Security**: Reducing custom server configurations minimizes the risk of misconfigurations or security vulnerabilities.

Overall, these changes aim to streamline our configuration and make our system more robust and maintainable.