### PR TITLE
revert oauth to frontend + upgrade 0.71.0

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.70.0
+version: 0.71.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -27,10 +27,6 @@ metadata:
   name: hub-api-ingress
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress }}
-    {{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
-    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
-    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
-    {{- end }}
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -96,39 +92,6 @@ spec:
               servicePort: 8081
     {{- end }}
   {{ end }}
-{{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: oauth2-proxy-api
-  namespace: kube-system
-  annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress }}
-    {{- if eq .Values.ingress "nginx" }}
-    cert-manager.io/cluster-issuer: letsencrypt-prod
-    kubernetes.io/tls-acme: "true"
-    nginx.ingress.kubernetes.io/ssl-redirect: "true"
-    nginx.ingress.kubernetes.io/enable-cors: "true"
-    {{- end }}
-spec:
-  ingressClassName: nginx
-  rules:
-    - host: "{{ .Values.kerberoshub.api.url }}"
-      http:
-        paths:
-          - path: /oauth2
-            pathType: Prefix
-            backend:
-              service:
-                name: oauth2-proxy
-                port:
-                  number: 4180
-  tls:
-    - hosts:
-        - "{{ .Values.kerberoshub.api.url }}"
-      secretName: 
-{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -23,6 +23,10 @@ metadata:
   name: hub-frontend-ingress
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress }}
+    {{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
+    nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
+    nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
+    {{- end }}
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -99,6 +103,39 @@ spec:
               servicePort: 80
     {{- end }}
   {{- end }}
+{{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: oauth2-proxy-frontend
+  namespace: kube-system
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress }}
+    {{- if eq .Values.ingress "nginx" }}
+    cert-manager.io/cluster-issuer: letsencrypt-prod
+    kubernetes.io/tls-acme: "true"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/enable-cors: "true"
+    {{- end }}
+spec:
+  ingressClassName: nginx
+  rules:
+    - host: "{{ .Values.kerberoshub.frontend.url }}"
+      http:
+        paths:
+          - path: /oauth2
+            pathType: Prefix
+            backend:
+              service:
+                name: oauth2-proxy
+                port:
+                  number: 4180
+  tls:
+    - hosts:
+        - "{{ .Values.kerberoshub.frontend.url }}"
+      secretName: 
+{{- end }}
 ---
 apiVersion: apps/v1
 kind: Deployment


### PR DESCRIPTION
### Pull Request Description

**Title:** Revert OAuth to Frontend + Upgrade to 0.71.0

**Motivation and Context:**
This pull request aims to address the integration of OAuth2 authentication specifically for the frontend, while also upgrading the chart version to 0.71.0. The motivation behind these changes is to improve the security and user experience by ensuring that OAuth2 authentication is correctly configured for the frontend portion of the application, rather than the backend. Additionally, upgrading to version 0.71.0 ensures that we are keeping up with the latest improvements and fixes in the chart.

**Changes:**
1. **Chart Version Upgrade:**
   - Upgraded the chart version from 0.70.0 to 0.71.0 in `charts/hub/Chart.yaml`.

2. **OAuth2 Proxy Configuration:**
   - Removed OAuth2 proxy configuration from the backend (`hub-api`) ingress in `charts/hub/templates/kerberos-hub/hub-api.yaml`.
   - Added OAuth2 proxy configuration to the frontend (`hub-frontend`) ingress in `charts/hub/templates/kerberos-hub/hub-frontend.yaml`.

By moving the OAuth2 proxy configuration to the frontend, we ensure that user authentication is handled appropriately at the entry point where user interaction occurs. This not only enhances security but also aligns with best practices for managing authentication flows.

Overall, these changes contribute to a more secure and robust deployment, ensuring that the user authentication process is correctly managed and that we are utilizing the latest updates available in the chart.