### PR TITLE
set kerberosvault to true (thumbnails)

### DIFF
--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -487,7 +487,7 @@ kerberospipeline:
     width: "600"
     height: "-1"
     kerberosvault:
-      enabled: false # If you want to use Kerberos Vault to store the thumbnails
+      enabled: true # If you want to use Kerberos Vault to store the thumbnails
     resources:
       requests:
         memory: 512Mi


### PR DESCRIPTION
## Description

### Pull Request Description: Set kerberosvault to True (Thumbnails)

#### Motivation
The primary motivation behind this change is to enable the use of Kerberos Vault for storing thumbnails. By setting `kerberosvault.enabled` to `true`, we can leverage the secure and efficient storage capabilities of Kerberos Vault, which will improve the overall management and retrieval of thumbnails.

#### Why It Improves the Project
1. **Enhanced Security**: Kerberos Vault provides a secure storage solution, ensuring that thumbnails are stored in a protected environment.
2. **Improved Efficiency**: By using Kerberos Vault, the project benefits from optimized storage and retrieval processes, leading to better performance.
3. **Centralized Management**: Storing thumbnails in Kerberos Vault allows for centralized management, making it easier to maintain and scale the storage system as the project grows.
4. **Future-Proofing**: Enabling Kerberos Vault prepares the project for future enhancements and integrations that may rely on secure and efficient storage solutions.

#### Changes Made
- Updated `charts/hub/values.yaml` to set `kerberosvault.enabled` from `false` to `true`.

```diff
  kerberosvault:
-    enabled: false # If you want to use Kerberos Vault to store the thumbnails
+    enabled: true # If you want to use Kerberos Vault to store the thumbnails
```

This change is repeated in multiple sections of the `charts/hub/values.yaml` file to ensure that Kerberos Vault is enabled consistently across different configurations.

By implementing this change, we enhance the project's security, efficiency, and scalability, aligning with our long-term goals for robust and reliable storage solutions.