### PR TITLE
Feature/inject namespace required for kustomize

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Kerberos.io ecosystem can be deployed through Helm charts. Use one of the following charts to boost the installation:
 
-- [Hub](https://github.com/kerberos-io/helm-charts/tree/main/charts/hub) chart
+- [Hub](https://github.com/kerberos-io/helm-charts/tree/main/charts/hub)
 
 ## Prerequisite
 

--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.74.0
+version: 0.75.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hub-api-svc
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: hub-api-svc
 spec:

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hub-api-svc
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     app: hub-api-svc
 spec:

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -28,7 +28,6 @@ kind: Ingress
 metadata:
   name: hub-api-ingress
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress }}
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
@@ -36,6 +35,7 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress }}
   {{- with .Values.kerberoshub.api.tls }}
   tls:
     {{- toYaml . | nindent 8 }}

--- a/charts/hub/templates/kerberos-hub/hub-cleanup.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-cleanup.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hub-cleanup
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: 1
   selector:

--- a/charts/hub/templates/kerberos-hub/hub-cleanup.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-cleanup.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hub-cleanup
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hub-frontend-demo-svc
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     app: hub-frontend-demo-svc
 spec:

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -24,13 +24,13 @@ kind: Ingress
 metadata:
   name: hub-frontend-demo-ingress
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress }}
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"
     nginx.ingress.kubernetes.io/ssl-redirect: "true"
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     {{- end }}
 spec:
+  ingressClassName: {{ .Values.ingress }}
   {{- with .Values.kerberoshub.frontend.demoTls }}
   tls:
     {{- toYaml . | nindent 8 }}

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hub-frontend-demo-svc
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: hub-frontend-demo-svc
 spec:

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hub-frontend-svc
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: hub-frontend-svc
 spec:

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -24,7 +24,6 @@ kind: Ingress
 metadata:
   name: hub-frontend-ingress
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress }}
     {{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
     nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
     nginx.ingress.kubernetes.io/auth-signin: "https://$host/oauth2/start?rd=$escaped_request_uri"
@@ -35,7 +34,7 @@ metadata:
     cert-manager.io/cluster-issuer: "letsencrypt-prod"
     {{- end }}
 spec:
-
+  ingressClassName: {{ .Values.ingress }}
   {{- with .Values.kerberoshub.frontend.tls }}
   tls:
     {{- toYaml . | nindent 8 }}
@@ -114,7 +113,6 @@ metadata:
   name: oauth2-proxy-frontend
   namespace: kube-system
   annotations:
-    kubernetes.io/ingress.class: {{ .Values.ingress }}
     {{- if eq .Values.ingress "nginx" }}
     cert-manager.io/cluster-issuer: letsencrypt-prod
     kubernetes.io/tls-acme: "true"
@@ -122,7 +120,7 @@ metadata:
     nginx.ingress.kubernetes.io/enable-cors: "true"
     {{- end }}
 spec:
-  ingressClassName: nginx
+  ingressClassName: {{ .Values.ingress }}
   rules:
     - host: "{{ .Values.kerberoshub.frontend.url }}"
       http:

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: hub-frontend-svc
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     app: hub-frontend-svc
 spec:

--- a/charts/hub/templates/kerberos-hub/hub-monitor-device.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-monitor-device.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hub-monitor-device
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/charts/hub/templates/kerberos-hub/hub-monitor-device.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-monitor-device.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hub-monitor-device
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: 1
   selector:

--- a/charts/hub/templates/kerberos-hub/hub-oauth2-proxy.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-oauth2-proxy.yaml
@@ -2,10 +2,10 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  labels:
-    k8s-app: oauth2-proxy
   name: oauth2-proxy
   namespace: kube-system
+  labels:
+    k8s-app: oauth2-proxy
 spec:
   replicas: 1
   selector:

--- a/charts/hub/templates/kerberos-hub/hub-reactivate-subscription.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-reactivate-subscription.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hub-reactivate-subscription
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/charts/hub/templates/kerberos-hub/hub-reactivate-subscription.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-reactivate-subscription.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hub-reactivate-subscription
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: 1
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-analysis.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-analysis.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-analysis
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.analysis.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-analysis.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-analysis.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-analysis
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.analysis.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-counting.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-counting.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-counting
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.counting.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-counting.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-counting.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-counting
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.counting.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-dominantcolor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-dominantcolor.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-dominantcolor
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.dominantColor.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-dominantcolor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-dominantcolor.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-dominantcolor
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.dominantColor.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-event.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-event.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-event
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.event.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-event.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-event.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-event
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.event.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-export.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-export.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-export
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.export.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-export.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-export.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-export
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.export.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-monitor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-monitor.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-monitor
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.monitor.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-monitor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-monitor.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-monitor
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.monitor.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-notify-test.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-notify-test.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-notify-test
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.notifyTest.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-notify-test.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-notify-test.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-notify-test
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.notifyTest.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-notify.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-notify.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-notify
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.notify.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-notify.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-notify.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-notify
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.notify.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-sequence.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-sequence.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-sequence
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.sequence.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-sequence.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-sequence.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-sequence
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.sequence.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-sprite.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-sprite.yaml
@@ -3,7 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-sprite
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.sprite.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-sprite.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-sprite.yaml
@@ -3,6 +3,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-sprite
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.sprite.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-throttler.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-throttler.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-throttler
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.throttler.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-throttler.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-throttler.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-throttler
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.throttler.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-thumbnail.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-thumbnail.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-thumbnail
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberospipeline.thumbnail.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-thumbnail.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-thumbnail.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: pipe-thumbnail
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: {{ .Values.kerberospipeline.thumbnail.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/servicemonitor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: hub-metrics-servicemonitor
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: { { .Release.Namespace } }
   labels:
     service: pipe
     release: prometheus

--- a/charts/hub/templates/kerberos-pipeline/servicemonitor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/servicemonitor.yaml
@@ -2,7 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: hub-metrics-servicemonitor
-  namespace: { { .Release.Namespace } }
+  namespace: {{ .Release.Namespace }}
   labels:
     service: pipe
     release: prometheus

--- a/charts/hub/templates/kerberos-pipeline/servicemonitor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/servicemonitor.yaml
@@ -2,6 +2,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: hub-metrics-servicemonitor
+  namespace: {{ include "common.names.namespace" . | quote }}
   labels:
     service: pipe
     release: prometheus

--- a/charts/hub/templates/kerberos-vault/vault-forwarder.yaml
+++ b/charts/hub/templates/kerberos-vault/vault-forwarder.yaml
@@ -4,6 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vault-forwarder
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: 1
   selector:

--- a/charts/hub/templates/kerberos-vault/vault-forwarder.yaml
+++ b/charts/hub/templates/kerberos-vault/vault-forwarder.yaml
@@ -4,7 +4,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vault-forwarder
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 1
   selector:

--- a/charts/hub/templates/kerberos-vault/vault-proxy.yaml
+++ b/charts/hub/templates/kerberos-vault/vault-proxy.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vault-proxy
-  namespace: {{ include "common.names.namespace" . | quote }}
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: 3
   selector:

--- a/charts/hub/templates/kerberos-vault/vault-proxy.yaml
+++ b/charts/hub/templates/kerberos-vault/vault-proxy.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: vault-proxy
+  namespace: {{ include "common.names.namespace" . | quote }}
 spec:
   replicas: 3
   selector:


### PR DESCRIPTION
## Description

## Pull Request Description

### Motivation

This pull request introduces the necessary changes to inject the namespace required for Kustomize into the Kerberos.io Helm charts. By explicitly defining the namespace for each resource, we ensure that the Helm charts are compatible with Kustomize and can be deployed consistently across different environments. This change enhances the flexibility and robustness of our deployment process.

### Changes Overview

1. **Namespace Injection:**
   - Added `namespace: {{ .Release.Namespace }}` to all relevant Kubernetes resource templates within the Helm charts. This ensures that resources are created in the correct namespace as specified during the Helm release.

2. **Ingress Class Annotation Update:**
   - Replaced the deprecated `kubernetes.io/ingress.class` annotation with `ingressClassName` to align with the latest Kubernetes best practices.

3. **Version Bump:**
   - Updated the chart version from `0.74.0` to `0.75.0` to reflect the changes and ensure proper versioning for Helm deployments.

4. **Documentation Fix:**
   - Corrected a minor formatting issue in the README file for better readability.

### Benefits

- **Compatibility with Kustomize:** Ensures that the Helm charts can be seamlessly used with Kustomize, enhancing deployment flexibility.
- **Namespace Consistency:** Explicit namespace definition helps avoid potential issues related to resource creation in unintended namespaces.
- **Modern Practices:** Updating the ingress class annotations to the recommended `ingressClassName` ensures compatibility with current and future Kubernetes versions.
- **Versioning:** Proper versioning allows users to track changes and updates effectively, ensuring smooth upgrades and maintenance.

By implementing these changes, we improve the overall deployment process, making it more reliable and adaptable to various deployment tools and environments.