### PR TITLE
Improvement / Missed some namespaces on several resources

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.75.0
+version: 0.76.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -27,6 +27,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: hub-api-ingress
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"
@@ -100,6 +101,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hub-api
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberoshub.api.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -23,6 +23,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: hub-frontend-demo-ingress
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- if eq .Values.ingress "nginx" }}
     kubernetes.io/tls-acme: "true"
@@ -63,6 +64,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hub-frontend-demo
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberoshub.frontend.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -23,6 +23,7 @@ apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: hub-frontend-ingress
+  namespace: {{ .Release.Namespace }}
   annotations:
     {{- if eq .Values.kerberoshub.oauth2Proxy.enabled true  }}
     nginx.ingress.kubernetes.io/auth-url: "https://$host/oauth2/auth"
@@ -142,6 +143,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hub-frontend
+  namespace: {{ .Release.Namespace }}
 spec:
   replicas: {{ .Values.kerberoshub.frontend.replicas }}
   selector:

--- a/charts/hub/templates/kerberos-pipeline/pipe-analysis.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-analysis.yaml
@@ -86,10 +86,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-analysis
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-analysis
     service: pipe
-  name: pipe-analysis
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-pipeline/pipe-counting.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-counting.yaml
@@ -62,10 +62,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-counting
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-counting
     service: pipe
-  name: pipe-counting
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-pipeline/pipe-dominantcolor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-dominantcolor.yaml
@@ -62,10 +62,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-dominantcolor
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-dominantcolor
     service: pipe
-  name: pipe-dominantcolor
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-pipeline/pipe-event.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-event.yaml
@@ -78,10 +78,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-event
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-event
     service: pipe
-  name: pipe-event
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-pipeline/pipe-export.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-export.yaml
@@ -112,10 +112,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-export
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-export
     service: pipe
-  name: pipe-export
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-pipeline/pipe-monitor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-monitor.yaml
@@ -97,10 +97,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-monitor
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-monitor
     service: pipe
-  name: pipe-monitor
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-pipeline/pipe-notify-test.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-notify-test.yaml
@@ -110,10 +110,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-notify-test
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-notify-test
     service: pipe
-  name: pipe-notify-test
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-pipeline/pipe-notify.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-notify.yaml
@@ -140,10 +140,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-notify
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-notify
     service: pipe
-  name: pipe-notify
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-pipeline/pipe-sequence.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-sequence.yaml
@@ -74,10 +74,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-sequence
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-sequence
     service: pipe
-  name: pipe-sequence
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-pipeline/pipe-sprite.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-sprite.yaml
@@ -86,10 +86,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-sprite
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-sprite
     service: pipe
-  name: pipe-sprite
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-pipeline/pipe-throttler.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-throttler.yaml
@@ -74,10 +74,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-throttler
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-throttler
     service: pipe
-  name: pipe-throttler
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-pipeline/pipe-thumbnail.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-thumbnail.yaml
@@ -88,10 +88,11 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  name: pipe-thumbnail
+  namespace: {{ .Release.Namespace }}
   labels:
     app: pipe-thumbnail
     service: pipe
-  name: pipe-thumbnail
 spec:
   ports:
     - name: hub-metrics

--- a/charts/hub/templates/kerberos-vault/vault-proxy.yaml
+++ b/charts/hub/templates/kerberos-vault/vault-proxy.yaml
@@ -48,6 +48,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: vault-proxy-svc
+  namespace: {{ .Release.Namespace }}
   labels:
     app: vault-proxy-svc
 spec:


### PR DESCRIPTION
## Description

### Pull Request Title: Improvement / Missed some namespaces on several resources

### Description:
This pull request addresses the missing namespace declarations in several Kubernetes resource definitions within the Helm charts. The changes ensure that all resources are correctly scoped to the namespace in which the Helm release is deployed.

### Motivation:
The primary motivation behind this change is to enhance the reliability and correctness of our Helm charts. By explicitly specifying the namespace for each resource, we prevent potential issues related to resource creation and management in multi-namespace environments. This change aligns with best practices for Kubernetes resource management and ensures that all resources are properly isolated within their intended namespace.

### Changes:
- Updated the version in `charts/hub/Chart.yaml` from `0.75.0` to `0.76.0`.
- Added `namespace: {{ .Release.Namespace }}` to the metadata of various Kubernetes resources, including:
  - Ingresses
  - Deployments
  - Services

### Benefits:
1. **Namespace Isolation**: Ensures that all resources are created within the correct namespace, preventing accidental cross-namespace resource access or conflicts.
2. **Consistency**: Aligns with Kubernetes best practices for resource management, making the chart more robust and easier to maintain.
3. **Reliability**: Reduces the risk of deployment failures due to namespace-related issues, especially in environments with multiple namespaces.

### Conclusion:
This improvement is crucial for maintaining the integrity and reliability of our Helm charts. By explicitly defining namespaces for all resources, we ensure that deployments are more predictable and manageable, leading to a more stable and consistent deployment process.