### PR TITLE
Allow editing of orphaned day limit

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.76.0
+version: 0.77.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-cleanup.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-cleanup.yaml
@@ -35,7 +35,7 @@ spec:
             - name: READ_ONLY
               value: "{{ .Values.readonly }}"
             - name: MAX_DAYS
-              value: "30"
+              value: "{{ .Values.kerberoshub.cleanup.maxDays }}"
             - name: MONGODB_DATABASE_CLOUD
               value: "Kerberos"
             - name: MONGODB_URI

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -340,6 +340,7 @@ kerberoshub:
     repository: kerberos/hub-cleanup
     pullPolicy: IfNotPresent
     tag: "1.0.6436406806"
+    maxDays: "365" # The maximum number of days to keep orphaned recordings.
     resources:
       requests:
         memory: 10Mi


### PR DESCRIPTION
## Description

### Pull Request Description

#### Motivation

The current configuration hardcodes the maximum number of days to keep orphaned recordings to 30 days. This limitation does not provide flexibility for different deployment requirements where a different retention period might be necessary.

#### Changes

- Modified `charts/hub/templates/kerberos-hub/hub-cleanup.yaml` to replace the hardcoded value of `MAX_DAYS` with a configurable value from the Helm chart values.
- Updated `charts/hub/values.yaml` to introduce a new configurable parameter `kerberoshub.cleanup.maxDays`, setting its default value to 365 days.

#### Benefits

- **Flexibility:** This change allows users to configure the maximum number of days to keep orphaned recordings according to their specific requirements.
- **Customization:** Users can now easily adjust the retention period without modifying the source code, making the deployment process more adaptable and user-friendly.
- **Scalability:** This improvement supports a wider range of use cases and deployment scenarios by providing a configurable retention period for orphaned recordings.

Overall, this change enhances the project's flexibility and usability, making it more adaptable to different operational needs.