### PR TITLE
Enable oauth proxy with admin

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.80.0
+version: 0.81.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/admin/oauth2-proxy.yaml
+++ b/charts/hub/templates/admin/oauth2-proxy.yaml
@@ -28,4 +28,69 @@ spec:
     - hosts:
         - "{{ .Values.admin.url }}"
       secretName: 
-{{- end }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oauth2-proxy-admin
+  namespace: kube-system
+  labels:
+    k8s-app: oauth2-proxy-admin
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      k8s-app: oauth2-proxy-admin
+  template:
+    metadata:
+      labels:
+        k8s-app: oauth2-proxy-admin
+    spec:
+      containers:
+        - args:
+            - --provider=github
+            - --email-domain=*
+            - --upstream=file:///dev/null
+            - --http-address=0.0.0.0:4180
+            - --skip-auth-preflight=true
+          env:
+            - name: OAUTH2_PROXY_CLIENT_ID
+              value: "{{ .Values.admin.oauth2Proxy.github.clientId }}"
+            - name: OAUTH2_PROXY_CLIENT_SECRET
+              value: "{{ .Values.admin.oauth2Proxy.github.clientSecret }}"
+            - name: OAUTH2_PROXY_COOKIE_SECRET
+              value: "{{ .Values.admin.oauth2Proxy.github.cookieSecret }}"
+            - name: OAUTH2_PROXY_GITHUB_ORG
+              value: "{{ .Values.admin.oauth2Proxy.github.organization }}"
+            - name: OAUTH2_PROXY_GITHUB_TEAM
+              value: "{{ .Values.admin.oauth2Proxy.github.team }}"
+          image: quay.io/oauth2-proxy/oauth2-proxy:latest
+          imagePullPolicy: Always
+          name: oauth2-proxy
+          ports:
+            - containerPort: 4180
+              protocol: TCP
+          resources:
+            limits:
+              cpu: 100m
+              memory: 50Mi
+            requests:
+              cpu: 100m
+              memory: 50Mi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    k8s-app: oauth2-proxy-admin
+  name: oauth2-proxy-admin
+  namespace: kube-system
+spec:
+  ports:
+    - name: http
+      port: 4180
+      protocol: TCP
+      targetPort: 4180
+  selector:
+    k8s-app: oauth2-proxy-admin
+{{- end -}}


### PR DESCRIPTION
## Description

### Pull Request: Enable OAuth Proxy with Admin

#### Motivation

The primary motivation for this change is to enhance the security and access control for the admin interface by integrating OAuth2 proxy. This will ensure that only authorized users, authenticated via GitHub, can access the admin functionalities. By enforcing OAuth2 authentication, we can better protect sensitive administrative operations and data.

#### Changes Overview

1. **Chart Version Update**: 
   - Bumped the chart version from `0.80.0` to `0.81.0` to reflect the new changes.
   
2. **OAuth2 Proxy Deployment**:
   - Added a new Kubernetes Deployment for `oauth2-proxy-admin` in the `kube-system` namespace.
   - Configured the deployment to use GitHub as the OAuth provider.
   - Set environment variables for OAuth2 proxy configuration using values from `values.yaml`.
   - Defined resource limits and requests to ensure efficient use of cluster resources.
   
3. **Service Configuration**:
   - Created a new Service to expose the OAuth2 proxy on port `4180` within the `kube-system` namespace.
   
4. **Ingress Configuration**:
   - Ensured that the Ingress configuration includes the necessary hosts and secret names for the admin interface.

#### Benefits

- **Enhanced Security**: By enabling OAuth2 proxy, we add an additional layer of authentication, ensuring that only authorized users can access the admin interface.
- **Centralized Authentication**: Using GitHub as the OAuth provider allows for centralized and managed authentication, leveraging existing GitHub user and team structures.
- **Resource Management**: Proper resource limits and requests ensure that the OAuth2 proxy does not consume excessive resources, maintaining cluster stability.

This change significantly improves the security posture of the admin interface, making it more robust against unauthorized access while leveraging existing authentication mechanisms.