### PR TITLE
feature/add-workflow-enabled

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.104.0
+version: 0.105.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -258,6 +258,8 @@ spec:
         # features > general
         - name: FEATURE_CASE_ENABLED
           value: "{{ .Values.kerberoshub.frontend.features.case.enabled }}"
+        - name: FEATURE_WORKFLOWS_ENABLED
+          value: "{{ .Values.kerberoshub.frontend.features.workflows.enabled }}"
         - name: FEATURE_DARK_MODE
           value: "{{ .Values.kerberoshub.frontend.features.darkMode }}"
         - name: FEATURE_LANDING_PAGE

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -339,6 +339,8 @@ spec:
         # features > general
         - name: FEATURE_CASE_ENABLED
           value: "{{ .Values.kerberoshub.frontend.features.case.enabled }}"
+        - name: FEATURE_WORKFLOWS_ENABLED
+          value: "{{ .Values.kerberoshub.frontend.features.workflows.enabled }}"
         - name: FEATURE_DARK_MODE
           value: "{{ .Values.kerberoshub.frontend.features.darkModeEnabled }}"
         - name: FEATURE_LANDING_PAGE

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -410,6 +410,9 @@ kerberoshub:
       # Case management is a feature that allows you to create cases, and link recordings, devices, sites, groups, markers and events to those cases. 
       case:
         enabled: "true" # Enable or disable case management feature 'true' or 'false'
+      # Workflows allow you to define automated processes and actions in the front-end.
+      workflows:
+        enabled: "false" # Enable or disable workflows feature 'true' or 'false'
       # Map tile configuration  
       map:
         tileUrlLight: "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png" # Map tile URL for light mode


### PR DESCRIPTION
Expose a WORKFLOWS feature flag to the frontend by adding FEATURE_WORKFLOWS_ENABLED to both hub-frontend and hub-frontend-demo deployment templates. Add a default `kerberoshub.frontend.features.workflows.enabled: "false"` in values.yaml so the feature is off by default. Bump chart version from 0.104.0 to 0.105.0 to reflect the changes.