### PR TITLE
feat(hub): add casesMaxRetentionDays cap

### DIFF
--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -353,6 +353,8 @@ spec:
               value: "{{ .Values.email.templates.assignTaskTitle }}"
             - name: DEFAULT_TASK_RETENTION_DAYS
               value: "{{ .Values.kerberoshub.api.defaultTaskRetentionDays }}"
+            - name: CASES_MAX_RETENTION_DAYS
+              value: "{{ .Values.kerberoshub.api.casesMaxRetentionDays }}"
 
             # SMTP
             - name: SMTP_SERVER

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -278,6 +278,10 @@ spec:
         - name: COLOR_DEVICE_MARKER_BORDER
           value: "{{ .Values.kerberoshub.frontend.colorDeviceMarkerBorder }}"
 
+        # features > video edits
+        - name: FEATURE_VIDEO_EDITS_ENABLED
+          value: "{{ .Values.kerberoshub.frontend.features.videoEdits.enabled }}"
+
         # features > face redaction 
         - name: FEATURE_FACE_REDACTION_ENABLED
           value: "{{ .Values.kerberoshub.frontend.features.faceRedaction.enabled }}" 

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -378,6 +378,10 @@ spec:
         - name: COLOR_CHART_GRID_STROKE
           value: "{{ .Values.kerberoshub.frontend.features.chart.colorChartGridStroke }}"
 
+        # features > video edits
+        - name: FEATURE_VIDEO_EDITS_ENABLED
+          value: "{{ .Values.kerberoshub.frontend.features.videoEdits.enabled }}"
+
         # features > face redaction 
         - name: FEATURE_FACE_REDACTION_ENABLED
           value: "{{ .Values.kerberoshub.frontend.features.faceRedaction.enabled }}" 

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -468,6 +468,9 @@ kerberoshub:
         colorTrackBoxHover: "hsla(47, 86%, 47%, 1)" # Boxes while hovering over the associated track
         colorTrackBoxDrawing: "hsla(204, 100%, 50%, 1)" # New box while drawing
         colorTrackBoxControlsDelete: "hsla(219, 100%, 94%, 1)" # Delete icon top right of the box while editing
+      # Video edits feature (umbrella flag for in-app video editing tools, e.g. face redaction)
+      videoEdits:
+        enabled: "false" # Enable or disable video edit tools 'true' or 'false'
       # Face redaction feature
       faceRedaction:
         enabled: "false" # Enable or disable face redaction 'true' or 'false'

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -247,6 +247,11 @@ kerberoshub:
     # unless an explicit value is provided). Must match the value used by
     # `kerberoshub.cleanup.defaultTaskRetentionDays`.
     defaultTaskRetentionDays: "0"
+    # Maximum retention (in days) allowed on a task. When a caller
+    # supplies an `expires_at` (or the default retention above resolves)
+    # beyond this cap, the value is clamped down to `now + casesMaxRetentionDays`.
+    # Set to "0" (or a negative value) to disable the cap (no maximum).
+    casesMaxRetentionDays: "0"
     ## Certificates
     tls:
       - hosts:


### PR DESCRIPTION
New optional value kerberoshub.api.casesMaxRetentionDays exposed to the hub-api container as CASES_MAX_RETENTION_DAYS. Acts as a hard ceiling on a task's expires_at; "0" (the default) disables the cap and preserves existing behavior. Mirrors the existing
defaultTaskRetentionDays plumbing.