### PR TITLE
feature/optional-disable-frontend-demo

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.112.0
+version: 0.113.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/admin/deployment.yaml
+++ b/charts/hub/templates/admin/deployment.yaml
@@ -14,12 +14,24 @@ spec:
       labels:
         app: admin
     spec:
+      {{- with .Values.admin.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admin.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: admin
           image: "{{ .Values.global.imageRegistry }}{{ .Values.admin.repository }}:{{ .Values.admin.tag }}"
           imagePullPolicy: {{ .Values.admin.pullPolicy }}
           {{- with .Values.admin.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.admin.volumeMounts }}
+          volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           ports:

--- a/charts/hub/templates/admin/oauth2-proxy.yaml
+++ b/charts/hub/templates/admin/oauth2-proxy.yaml
@@ -46,6 +46,14 @@ spec:
       labels:
         k8s-app: oauth2-proxy-admin
     spec:
+      {{- with .Values.admin.oauth2Proxy.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.admin.oauth2Proxy.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - args:
             - --provider=github
@@ -53,6 +61,10 @@ spec:
             - --upstream=file:///dev/null
             - --http-address=0.0.0.0:4180
             - --skip-auth-preflight=true
+          {{- with .Values.admin.oauth2Proxy.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: OAUTH2_PROXY_CLIENT_ID
               value: "{{ .Values.admin.oauth2Proxy.github.clientId }}"

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -1,4 +1,5 @@
 {{- if or (eq .Values.mode "all") (eq .Values.mode "ui") -}}
+{{- if .Values.kerberoshub.api.serviceEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -18,6 +19,7 @@ spec:
       protocol: TCP
   selector:
     app: hub-api
+{{- end }}
 {{ if ne .Values.ingress "" }}
 ---
 {{ if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
@@ -139,6 +141,10 @@ spec:
           secret:
             secretName: {{ $serverTLS.secretName }}
       {{- end }}
+      {{- end }}
+      {{- with .Values.kerberoshub.api.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: hub-api

--- a/charts/hub/templates/kerberos-hub/hub-cleanup.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-cleanup.yaml
@@ -29,12 +29,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberoshub.cleanup.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberoshub.cleanup.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: hub-cleanup
           image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberoshub.cleanup.repository }}:{{ .Values.kerberoshub.cleanup.tag }}"
           imagePullPolicy: {{ .Values.kerberoshub.cleanup.pullPolicy }}
           {{- with .Values.kerberoshub.cleanup.resources }}
           resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.kerberoshub.cleanup.volumeMounts }}
+          volumeMounts:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           envFrom:

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.mode "all") (eq .Values.mode "ui") -}}
+{{- if and (or (eq .Values.mode "all") (eq .Values.mode "ui")) .Values.kerberoshub.frontend.demoEnabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -91,6 +91,10 @@ spec:
       {{- end }}
       {{- with .Values.kerberoshub.frontend.volumes }}
       volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberoshub.frontend.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -1,4 +1,5 @@
 {{- if or (eq .Values.mode "all") (eq .Values.mode "ui") -}}
+{{- if .Values.kerberoshub.frontend.serviceEnabled }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -14,6 +15,7 @@ spec:
     name: http
   selector:
     app: hub-frontend
+{{- end }}
 {{ if ne .Values.ingress "" }}
 ---
 {{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1" }}
@@ -170,6 +172,10 @@ spec:
       {{- end }}
       {{- with .Values.kerberoshub.frontend.volumes }}
       volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberoshub.frontend.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:

--- a/charts/hub/templates/kerberos-hub/hub-monitor-device.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-monitor-device.yaml
@@ -33,6 +33,10 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberoshub.monitordevice.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: hub-monitor-device
           image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberoshub.monitordevice.repository }}:{{ .Values.kerberoshub.monitordevice.tag }}"

--- a/charts/hub/templates/kerberos-hub/hub-oauth2-proxy.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-oauth2-proxy.yaml
@@ -16,6 +16,14 @@ spec:
       labels:
         k8s-app: oauth2-proxy
     spec:
+      {{- with .Values.kerberoshub.oauth2Proxy.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberoshub.oauth2Proxy.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - args:
             - --provider=github
@@ -23,6 +31,10 @@ spec:
             - --upstream=file:///dev/null
             - --http-address=0.0.0.0:4180
             - --skip-auth-preflight=true
+          {{- with .Values.kerberoshub.oauth2Proxy.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             - name: OAUTH2_PROXY_CLIENT_ID
               value: "{{ .Values.kerberoshub.oauth2Proxy.github.clientId }}"

--- a/charts/hub/templates/kerberos-hub/hub-reactivate-subscription.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-reactivate-subscription.yaml
@@ -26,10 +26,22 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberoshub.reactivate.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberoshub.reactivate.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: hub-reactivate-subscription
           image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberoshub.reactivate.repository }}:{{ .Values.kerberoshub.reactivate.tag }}"
           imagePullPolicy: {{ .Values.kerberoshub.reactivate.pullPolicy }}
+          {{- with .Values.kerberoshub.reactivate.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: mongodb-config

--- a/charts/hub/templates/kerberos-pipeline/pipe-analysis.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-analysis.yaml
@@ -29,12 +29,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.analysis.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberospipeline.analysis.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-analysis
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.analysis.repository }}:{{ .Values.kerberospipeline.analysis.tag }}"
         imagePullPolicy: {{ .Values.kerberospipeline.analysis.pullPolicy }}
         {{- with .Values.kerberospipeline.analysis.resources }}
         resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.kerberospipeline.analysis.volumeMounts }}
+        volumeMounts:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         envFrom:

--- a/charts/hub/templates/kerberos-pipeline/pipe-counting.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-counting.yaml
@@ -27,12 +27,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.counting.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberospipeline.counting.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-counting
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.counting.repository }}:{{ .Values.kerberospipeline.counting.tag }}"
         imagePullPolicy: {{ .Values.kerberospipeline.counting.pullPolicy }}
         {{- with .Values.kerberospipeline.counting.resources }}
         resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.kerberospipeline.counting.volumeMounts }}
+        volumeMounts:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         env:

--- a/charts/hub/templates/kerberos-pipeline/pipe-dominantcolor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-dominantcolor.yaml
@@ -27,12 +27,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.dominantColor.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberospipeline.dominantColor.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-dominantcolor
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.dominantColor.repository }}:{{ .Values.kerberospipeline.dominantColor.tag }}"
         imagePullPolicy: {{ .Values.kerberospipeline.dominantColor.pullPolicy }}
         {{- with .Values.kerberospipeline.dominantColor.resources }}
         resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.kerberospipeline.dominantColor.volumeMounts }}
+        volumeMounts:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         env:

--- a/charts/hub/templates/kerberos-pipeline/pipe-event.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-event.yaml
@@ -29,12 +29,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.event.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberospipeline.event.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-event
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.event.repository }}:{{ .Values.kerberospipeline.event.tag }}"
         imagePullPolicy: {{ .Values.kerberospipeline.event.pullPolicy }}
         {{- with .Values.kerberospipeline.event.resources }}
         resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.kerberospipeline.event.volumeMounts }}
+        volumeMounts:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         ports:

--- a/charts/hub/templates/kerberos-pipeline/pipe-export.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-export.yaml
@@ -33,6 +33,10 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.export.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-export
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.export.repository }}:{{ .Values.kerberospipeline.export.tag }}"

--- a/charts/hub/templates/kerberos-pipeline/pipe-monitor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-monitor.yaml
@@ -29,12 +29,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.monitor.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberospipeline.monitor.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-monitor
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.monitor.repository }}:{{ .Values.kerberospipeline.monitor.tag }}"
         imagePullPolicy: {{ .Values.kerberospipeline.monitor.pullPolicy }}
         {{- with .Values.kerberospipeline.monitor.resources }}
         resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.kerberospipeline.monitor.volumeMounts }}
+        volumeMounts:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         envFrom:

--- a/charts/hub/templates/kerberos-pipeline/pipe-notify-test.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-notify-test.yaml
@@ -33,6 +33,10 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.notifyTest.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-notify-test
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.notifyTest.repository }}:{{ .Values.kerberospipeline.notifyTest.tag }}"

--- a/charts/hub/templates/kerberos-pipeline/pipe-notify.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-notify.yaml
@@ -33,6 +33,10 @@ spec:
       volumes:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.notify.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-notify
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.notify.repository }}:{{ .Values.kerberospipeline.notify.tag }}"

--- a/charts/hub/templates/kerberos-pipeline/pipe-redaction.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-redaction.yaml
@@ -27,12 +27,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.redaction.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberospipeline.redaction.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-redaction
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.redaction.repository }}:{{ .Values.kerberospipeline.redaction.tag }}"
         imagePullPolicy: {{ .Values.kerberospipeline.redaction.pullPolicy }}
         {{- with .Values.kerberospipeline.redaction.resources }}
         resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.kerberospipeline.redaction.volumeMounts }}
+        volumeMounts:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         env:

--- a/charts/hub/templates/kerberos-pipeline/pipe-sequence.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-sequence.yaml
@@ -29,12 +29,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.sequence.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberospipeline.sequence.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-sequence
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.sequence.repository }}:{{ .Values.kerberospipeline.sequence.tag }}"
         imagePullPolicy: {{ .Values.kerberospipeline.sequence.pullPolicy }}
         {{- with .Values.kerberospipeline.sequence.resources }}
         resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.kerberospipeline.sequence.volumeMounts }}
+        volumeMounts:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         envFrom:

--- a/charts/hub/templates/kerberos-pipeline/pipe-sprite.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-sprite.yaml
@@ -27,12 +27,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.sprite.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberospipeline.sprite.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-sprite
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.sprite.repository }}:{{ .Values.kerberospipeline.sprite.tag }}"
         imagePullPolicy: {{ .Values.kerberospipeline.sprite.pullPolicy }}        
         {{- with .Values.kerberospipeline.sprite.resources }}
         resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.kerberospipeline.sprite.volumeMounts }}
+        volumeMounts:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         env:

--- a/charts/hub/templates/kerberos-pipeline/pipe-throttler.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-throttler.yaml
@@ -29,12 +29,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.throttler.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberospipeline.throttler.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-throttler
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.throttler.repository }}:{{ .Values.kerberospipeline.throttler.tag }}"
         imagePullPolicy: {{ .Values.kerberospipeline.throttler.pullPolicy }}
         {{- with .Values.kerberospipeline.throttler.resources }}
         resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.kerberospipeline.throttler.volumeMounts }}
+        volumeMounts:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         envFrom:

--- a/charts/hub/templates/kerberos-pipeline/pipe-thumbnail.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-thumbnail.yaml
@@ -27,12 +27,24 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberospipeline.thumbnail.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberospipeline.thumbnail.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
       - name: pipe-thumbnail
         image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberospipeline.thumbnail.repository }}:{{ .Values.kerberospipeline.thumbnail.tag }}"
         imagePullPolicy: {{ .Values.kerberospipeline.thumbnail.pullPolicy }}
         {{- with .Values.kerberospipeline.thumbnail.resources }}
         resources:
+          {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.kerberospipeline.thumbnail.volumeMounts }}
+        volumeMounts:
           {{- toYaml . | nindent 12 }}
         {{- end }}
         env:

--- a/charts/hub/templates/kerberos-vault/vault-forwarder.yaml
+++ b/charts/hub/templates/kerberos-vault/vault-forwarder.yaml
@@ -27,6 +27,14 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberoshub.forwarder.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberoshub.forwarder.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: vault-forwarder
           image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberoshub.forwarder.repository }}:{{ .Values.kerberoshub.forwarder.tag }}"
@@ -35,6 +43,10 @@ spec:
             requests:
               memory: 10Mi
               cpu: 10m
+          {{- with .Values.kerberoshub.forwarder.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           envFrom:
           - configMapRef:
               name: mongodb-config

--- a/charts/hub/templates/kerberos-vault/vault-proxy.yaml
+++ b/charts/hub/templates/kerberos-vault/vault-proxy.yaml
@@ -24,10 +24,22 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.kerberoshub.proxy.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.kerberoshub.proxy.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: vault-proxy
           image: "{{ .Values.global.imageRegistry }}{{ .Values.kerberoshub.proxy.repository }}:{{ .Values.kerberoshub.proxy.tag }}"
           imagePullPolicy: {{ .Values.kerberoshub.proxy.pullPolicy }}
+          {{- with .Values.kerberoshub.proxy.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - containerPort: 8080
               name: http

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -163,6 +163,23 @@ admin:
   pullPolicy: IfNotPresent
   tag: "v1.3.0"
   replicas: 2
+  # Optional pod topology spread constraints for this deployment. Empty by
+  # default. Example:
+  #   topologySpreadConstraints:
+  #     - maxSkew: 1
+  #       topologyKey: kubernetes.io/hostname
+  #       whenUnsatisfiable: ScheduleAnyway
+  #       labelSelector:
+  #         matchLabels:
+  #           app: admin
+  topologySpreadConstraints: []
+  # Optional extra volumes / volumeMounts for this deployment (empty = none).
+  #volumes:
+  #  - name: extra
+  #    emptyDir: {}
+  #volumeMounts:
+  #  - name: extra
+  #    mountPath: /data
   logLevel: "info" # possible values: trace, debug, info, warn, error
   resources:
     requests:
@@ -175,6 +192,14 @@ admin:
       secretName: admin
   oauth2Proxy:
     enabled: false
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     github:
       clientId: "github-client-id"
       clientSecret: "github-client-secret"
@@ -203,6 +228,10 @@ kerberoshub:
     pullPolicy: IfNotPresent
     tag: "v1.9.8"
     replicas: 2
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Set to false to skip rendering the hub-api Service (e.g. when an
+    # external/shared Service is managed elsewhere).
+    serviceEnabled: true
     logLevel: "info" # possible values: trace, debug, info, warn, error
     jwtSecret: "this-is-a-secret-please-change-to-random-string" # change to a random value, this is for generating JWT tokens.
     schema: "https"
@@ -312,6 +341,10 @@ kerberoshub:
     pullPolicy: IfNotPresent
     tag: "v1.9.11"
     replicas: 2
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Set to false to skip rendering the hub-frontend Service (e.g. when an
+    # external/shared Service is managed elsewhere).
+    serviceEnabled: true
     logLevel: "info" # possible values: trace, debug, info, warn, error
     schema: "https"
     url: "yourdomain.com"
@@ -322,7 +355,9 @@ kerberoshub:
       limits:
         memory: 50Mi
         cpu: 50m
-    # The front-end but in read-only mode
+    # The front-end but in read-only mode. Set demoEnabled to true to deploy
+    # the demo front-end (service, ingress and deployment).
+    demoEnabled: false
     #demoUrl: "demo.yourdomain.com"
     # When migrating to another url, this might help migrating.
     #legacyUrl: "legacy.yourdomain.com"
@@ -500,6 +535,14 @@ kerberoshub:
     enabled: false
   oauth2Proxy:
     enabled: false
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     github:
       clientId: "github-client-id"
       clientSecret: "github-client-secret"
@@ -511,6 +554,14 @@ kerberoshub:
     pullPolicy: IfNotPresent
     tag: "v1.4.13"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     mode: "serve" # The mode the cleanup service operates in: serve | dry-run | version
     logLevel: "info" # possible values: trace, debug, info, warn, error
     maxDays: "365" # Hard maximum age (days) for global orphan cleanup.
@@ -546,6 +597,7 @@ kerberoshub:
     pullPolicy: IfNotPresent
     tag: "v1.4.0"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
     logLevel: "info" # possible values: trace, debug, info, warn, error
     resources:
       requests:
@@ -564,6 +616,14 @@ kerberoshub:
     pullPolicy: IfNotPresent
     tag: "v1.0.2"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     logLevel: "info" # possible values: trace, debug, info, warn, error
     resources:
       requests:
@@ -571,6 +631,14 @@ kerberoshub:
         cpu: 10m
   forwarder:
     enabled: false
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     #repository: kerberos/vault-forwarder
     #pullPolicy: IfNotPresent
     #tag: "1.0.2732389692"
@@ -584,6 +652,14 @@ kerberoshub:
     pullPolicy: IfNotPresent
     tag: "v1.0.0"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     logLevel: "info" # possible values: trace, debug, info, warn, error
     resources:
       requests:
@@ -599,6 +675,14 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.3.0"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     logLevel: "info" # possible values: trace, debug, info, warn, error
     resources:
       requests:
@@ -609,6 +693,14 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.3.9"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     resources:
       requests:
         memory: 10Mi
@@ -618,6 +710,14 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.6.18"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     resources:
       requests:
         memory: 10Mi
@@ -627,6 +727,14 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.2.0"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     logLevel: "info" # possible values: trace, debug, info, warn, error
     resources:
       requests:
@@ -637,6 +745,7 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.3.9"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
     logLevel: "info" # possible values: trace, debug, info, warn, error
     resources:
       requests:
@@ -655,6 +764,7 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.2.1"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
     resources:
       requests:
         memory: 10Mi
@@ -672,6 +782,14 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.7.8"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     logLevel: "info" # possible values: trace, debug, info, warn, error
     resources:
       requests:
@@ -682,6 +800,14 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v2.0.2"
     replicas: 3 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     logLevel: "info" # possible values: trace, debug, info, warn,
     resources:
       requests:
@@ -695,6 +821,14 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.3.4"
     replicas: 2 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     logLevel: "info" # possible values: trace, debug, info, warn, error
     quality: "1" # 1 (best) - 31 (worst)
     width: "600"
@@ -713,6 +847,14 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.6.3"
     replicas: 1 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     logLevel: "info" # possible values: trace, debug, info, warn,
     resources:
       requests:
@@ -724,6 +866,14 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.1.12"
     replicas: 5 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     logLevel: "info" # possible values: trace, debug, info, warn,
     interval: "1" # Number of secondes between each thumbnail in the sprite
     width: "240" # Should not be changed for the moment (hard coded in UI)
@@ -740,6 +890,7 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.2.4"
     replicas: 2 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
     logLevel: "info" # possible values: trace, debug, info, warn, error
     # playerAssetsPath: "/custom/player-assets/" # Path to custom player.html template (overrides the embedded default)
     # volumeMounts:
@@ -758,6 +909,14 @@ kerberospipeline:
     pullPolicy: IfNotPresent
     tag: "v1.0.0"
     replicas: 2 # Number of pods for the service.
+    topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
+    # Optional extra volumes / volumeMounts for this deployment (empty = none).
+    #volumes:
+    #  - name: extra
+    #    emptyDir: {}
+    #volumeMounts:
+    #  - name: extra
+    #    mountPath: /data
     logLevel: "info" # possible values: trace, debug, info, warn, error
     resources:
       requests:


### PR DESCRIPTION
Bump chart version to 0.113.0 and add optional pod topologySpreadConstraints, volumes and volumeMounts hooks across many templates (admin, oauth2-proxy, kerberoshub services, kerberospipeline components, and vault components). Add conditionals to control rendering of hub-api and hub-frontend Services and make the demo front-end conditional on demoEnabled. Update values.yaml with new defaults (empty arrays) and commented examples for topologySpreadConstraints, volumes and volumeMounts for each relevant component.