### PR TITLE
feature/live-view-mode

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.116.0
+version: 0.117.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend-demo.yaml
@@ -241,6 +241,8 @@ spec:
           value: "{{ .Values.kerberoshub.frontend.features.i18n.defaultLanguage }}"
 
         # features > liveview
+        - name: FEATURE_LIVE_STREAM_MODE
+          value: "{{ .Values.kerberoshub.frontend.features.liveview.liveStreamMode }}"
         - name: FEATURE_LIVEVIEW_PAGINATION_MODE
           value: "{{ .Values.kerberoshub.frontend.features.liveview.paginationMode }}"
         - name: FEATURE_LIVEVIEW_PAGE_SIZE

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -326,6 +326,8 @@ spec:
         # features > liveview
         - name: FEATURE_DEFAULT_STREAM_MODE
           value: "{{ .Values.kerberoshub.frontend.features.liveview.defaultStreamMode }}"
+        - name: FEATURE_LIVE_STREAM_MODE
+          value: "{{ .Values.kerberoshub.frontend.features.liveview.liveStreamMode }}"
         - name: FEATURE_LIVEVIEW_PAGINATION_MODE
           value: "{{ .Values.kerberoshub.frontend.features.liveview.paginationMode }}"
         - name: FEATURE_LIVEVIEW_PAGE_SIZE

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -469,6 +469,7 @@ kerberoshub:
       # Live view page
       liveview:
         defaultStreamMode: "SD" # Default stream mode 'SD' or 'HD' (will be migrated to 'preview' or 'live')
+        liveStreamMode: "webrtc" # Transport backing the LIVE (HD) mode 'webrtc' (default) or 'hls' (firewall-friendly, no TURN required)
         paginationMode: "scroll" # Pagination mode in live view 'scroll', 'numbered' or 'maxStreams'
         pageSize: "6" # Max streams shown per page when paginationMode is 'numbered' (4, 8, 12, 16 or 25)
         maxStreams: "-1" # Maximum number of live streams to show in live view, -1 for unlimited


### PR DESCRIPTION
Expose FEATURE_LIVE_STREAM_MODE environment variable in both hub-frontend and hub-frontend-demo templates, sourcing from .Values.kerberoshub.frontend.features.liveview.liveStreamMode. Add a new liveStreamMode default in charts/hub/values.yaml ("webrtc") to control the transport for LIVE (HD) mode (options: "webrtc" (default) or "hls"). This enables configuring live stream transport without modifying templates.