### PR TITLE
Gate OTel env vars behind opentelemetry.enabled and align workflows queue name

### DIFF
--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -408,6 +408,7 @@ spec:
             {{- toYaml .Values.kerberoshub.extraEnv | nindent 12 }}
             {{- end }}
 
+            {{- if .Values.opentelemetry.enabled }}
             # Open Telemetry tracing
             - name: OTEL_EXPORTED_OTLP_ENABLED
               value: "{{ .Values.opentelemetry.enabled }}"
@@ -415,4 +416,5 @@ spec:
               value: "{{ .Values.opentelemetry.routingEnabled }}"
             - name: OTEL_EXPORTER_OTLP_ENDPOINT
               value: "{{ .Values.opentelemetry.collector.endpoint }}"
+            {{- end }}
 {{- end }}

--- a/charts/hub/templates/kerberos-pipeline/hub-workflows.yaml
+++ b/charts/hub/templates/kerberos-pipeline/hub-workflows.yaml
@@ -87,6 +87,7 @@ spec:
         - name: KERBEROS_STORAGE_SECRET
           value: "{{ .Values.kerberosvault.secretkey }}"
 
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -94,6 +95,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-analysis.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-analysis.yaml
@@ -87,6 +87,12 @@ spec:
         # runs unchanged). Kept in sync with whether the workflows service runs.
         - name: WORKFLOWS_ENABLED
           value: "{{ .Values.kerberoshub.workflows.enabled }}"
+
+        # Queue analysis publishes opened workflow runs to (WORKFLOWS_QUEUE),
+        # taken from the workflows service's queue so analysis and the engine
+        # always agree on the queue name (no drift).
+        - name: WORKFLOWS_QUEUE
+          value: "{{ .Values.kerberoshub.services.workflows.queue }}"
           
         # Kerberos Vault
         - name: KERBEROS_STORAGE_URI
@@ -100,6 +106,7 @@ spec:
         - name: SPRITE_ENABLED
           value: "{{ .Values.kerberospipeline.sprite.enabled }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -107,6 +114,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-counting.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-counting.yaml
@@ -77,6 +77,7 @@ spec:
         - name: RABBITMQ_PASSWORD
           value: "{{ .Values.rabbitmq.password }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -84,6 +85,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-dominantcolor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-dominantcolor.yaml
@@ -77,6 +77,7 @@ spec:
         - name: RABBITMQ_PASSWORD
           value: "{{ .Values.rabbitmq.password }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -84,6 +85,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-event.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-event.yaml
@@ -86,6 +86,7 @@ spec:
         - name: RABBITMQ_PASSWORD
           value: "{{ .Values.rabbitmq.password }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -93,6 +94,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-export.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-export.yaml
@@ -122,6 +122,7 @@ spec:
         - name: VAULT_THUMBNAIL_SECRET_KEY
           value: "{{ .Values.kerberosvault.thumbnail.secretKey }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -129,6 +130,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-monitor.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-monitor.yaml
@@ -103,6 +103,7 @@ spec:
         - name: SMTP_PASSWORD
           value: "{{ .Values.email.smtp.password }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -110,6 +111,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-notify-test.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-notify-test.yaml
@@ -110,6 +110,7 @@ spec:
         - name: SMTP_PASSWORD
           value: "{{ .Values.email.smtp.password }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -117,6 +118,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-notify.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-notify.yaml
@@ -142,6 +142,7 @@ spec:
         - name: VAULT_SPRITE_SECRET_KEY
           value: "{{ .Values.kerberosvault.sprite.secretKey }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -149,6 +150,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-redaction.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-redaction.yaml
@@ -87,6 +87,7 @@ spec:
         - name: KERBEROS_STORAGE_SECRET
           value: "{{ .Values.kerberosvault.secretkey }}"
 
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -94,6 +95,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-sequence.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-sequence.yaml
@@ -80,6 +80,7 @@ spec:
         - name: RABBITMQ_PASSWORD
           value: "{{ .Values.rabbitmq.password }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -87,6 +88,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-sprite.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-sprite.yaml
@@ -100,6 +100,7 @@ spec:
         - name: VAULT_SPRITE_HEIGHT
           value: "{{ .Values.kerberospipeline.sprite.height }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -107,6 +108,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-throttler.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-throttler.yaml
@@ -82,6 +82,7 @@ spec:
         - name: RABBITMQ_PASSWORD
           value: "{{ .Values.rabbitmq.password }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -89,6 +90,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/hub/templates/kerberos-pipeline/pipe-thumbnail.yaml
+++ b/charts/hub/templates/kerberos-pipeline/pipe-thumbnail.yaml
@@ -103,6 +103,7 @@ spec:
         - name: VAULT_THUMBNAIL_SECRET_KEY
           value: "{{ .Values.kerberosvault.thumbnail.secretKey }}"
         
+        {{- if .Values.opentelemetry.enabled }}
         # Open Telemetry tracing
         - name: OTEL_EXPORTED_OTLP_ENABLED
           value: "{{ .Values.opentelemetry.enabled }}"
@@ -110,6 +111,7 @@ spec:
           value: "{{ .Values.opentelemetry.routingEnabled }}"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
           value: "{{ .Values.opentelemetry.collector.endpoint }}"
+        {{- end }}
 
 ---
 apiVersion: v1

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -121,7 +121,12 @@ opentelemetry:
   enabled: false
   routingEnabled: false
   collector:
-    endpoint: "http://otel-collector:4317"
+    # NOTE: the services use the OTLP *HTTP* exporter, so this must be the
+    # collector's HTTP port (4318) and must include the scheme. Use http://
+    # for a plaintext in-cluster collector (e.g. Jaeger) and https:// only if
+    # the collector terminates TLS. A scheme-less value defaults to TLS and
+    # fails against a plaintext collector ("server gave HTTP response to HTTPS client").
+    endpoint: "http://otel-collector:4318"
 ############################################
 # OpenAI configuration (semantic search)
 #
@@ -722,7 +727,7 @@ kerberoshub:
       logLevel: "info" # possible values: trace, debug, info, warn, error
       # Queue this service consumes ingest events and upstream results from
       # (WORKFLOWS_QUEUE). Must be fed the same messages the analysis service sees.
-      queue: "kcloud-workflows-queue"
+      queue: "hub-workflows-queue"
       resources:
         requests:
           memory: 10Mi


### PR DESCRIPTION
## Summary

This PR bundles three related deployment-config fixes for the `hub` chart.

### 1. Gate OpenTelemetry env vars behind `opentelemetry.enabled`
The `OTEL_*` tracing env vars were always injected, even when `opentelemetry.enabled: false`. They are now wrapped in `{{- if .Values.opentelemetry.enabled }}` so disabled tracing injects no `OTEL_*` variables. Applied to `hub-api` and every pipeline template:

`hub-api`, `hub-workflows`, `pipe-analysis`, `pipe-counting`, `pipe-dominantcolor`, `pipe-event`, `pipe-export`, `pipe-monitor`, `pipe-notify`, `pipe-notify-test`, `pipe-redaction`, `pipe-sequence`, `pipe-sprite`, `pipe-throttler`, `pipe-thumbnail`.

### 2. Fix OTLP collector endpoint default
Changed the default from `http://otel-collector:4317` to `http://otel-collector:4318`. The services use the OTLP **HTTP** exporter, so the endpoint must point at the collector's HTTP port (`4318`) and include the scheme. A scheme-less / `4317` value defaults to TLS and fails against a plaintext collector (`server gave HTTP response to HTTPS client`). Added an explanatory comment in `values.yaml`.

### 3. Align workflows queue name
- Renamed the workflows queue from `kcloud-workflows-queue` to `hub-workflows-queue` in `values.yaml`.
- Pass `WORKFLOWS_QUEUE` to the analysis pipeline (sourced from the workflows service's queue) so the analysis service and the workflows engine always agree on the queue name and don't drift.

## Changes
- `charts/hub/values.yaml`
- `charts/hub/templates/kerberos-hub/hub-api.yaml`
- `charts/hub/templates/kerberos-pipeline/*.yaml` (15 templates)

## Testing
- `helm lint charts/hub`
- `helm template hub charts/hub` with `opentelemetry.enabled` both `true` and `false` to confirm the `OTEL_*` vars are conditionally rendered.
