### PR TITLE
feat(hub): add case-share email template + env wiring

### DIFF
--- a/.github/workflows/workflows-queue-consistency.yaml
+++ b/.github/workflows/workflows-queue-consistency.yaml
@@ -1,0 +1,28 @@
+name: Workflows queue consistency
+
+# Fails the build if the analysis producer, the workflows engine and the stage
+# workers would render onto different WORKFLOWS_QUEUE names — the silent
+# producer/consumer queue-name drift that leaves runs piling up with no
+# consumer. Pure `helm template` render check, no cluster required.
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'charts/hub/**'
+      - 'scripts/check-workflows-queue-consistency.sh'
+      - '.github/workflows/workflows-queue-consistency.yaml'
+
+jobs:
+  check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.16.2
+
+      - name: Check WORKFLOWS_QUEUE consistency
+        run: ./scripts/check-workflows-queue-consistency.sh charts/hub

--- a/.github/workflows/workflows-queue-consistency.yaml
+++ b/.github/workflows/workflows-queue-consistency.yaml
@@ -12,6 +12,9 @@ on:
       - 'scripts/check-workflows-queue-consistency.sh'
       - '.github/workflows/workflows-queue-consistency.yaml'
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-24.04

--- a/charts/hub/custom-layout/templates/share_case.html
+++ b/charts/hub/custom-layout/templates/share_case.html
@@ -1,0 +1,418 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1"
+    />
+    <meta name="description" content="Kerberos.io Mailing">
+    <style type="text/css">
+
+        @font-face {
+            font-family: 'Inter';
+            font-style:  normal;
+            font-weight: 400;
+            font-display: swap;
+            src: url("https://kerberos.io/dist/fonts/Inter-Regular.woff?v=/dist/fonts/Inter-Regular.woff2?v=3.183.18") format("woff2"),
+            url("https://kerberos.io/dist/fonts/Inter-Regular.woff?v=/dist/fonts/Inter-Regular.woff2?v=3.183.18") format("woff");
+        }
+
+        @font-face {
+            font-family: 'Inter';
+            font-style:  normal;
+            font-weight: 500;
+            font-display: swap;
+            src: url("https://kerberos.io/dist/fonts/Inter-Medium.woff2?v=3.18") format("woff2"),
+            url("https://kerberos.io/dist/fonts/Inter-Medium.woff?v=3.18") format("woff");
+        }
+
+        @font-face {
+            font-family: 'Inter';
+            font-style:  normal;
+            font-weight: 600;
+            font-display: swap;
+            src: url("https://kerberos.io/dist/fonts/Inter-SemiBold.woff2?v=3.18") format("woff2"),
+            url("https://kerberos.io/dist/fonts/Inter-SemiBold.woff?v=3.18") format("woff");
+        }
+
+        @font-face {
+            font-family: 'Inter var';
+            font-weight: 100 900;
+            font-display: swap;
+            font-style: normal;
+            font-named-instance: 'Regular';
+            src: url("https://kerberos.io/dist/fonts/Inter-roman.var.woff2?v=3.18") format("woff2");
+        }
+
+        body{
+            background: #E5E5E5;
+            margin-top:0;
+            margin-bottom: 0;
+            margin-right: 0;
+            margin-left: 0;
+            padding-top: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-bottom: 0;
+            font-family: 'Inter';
+        }
+        a, a:hover, a:active {
+            color: #262424;
+            text-decoration: none;
+        }
+
+        .corner-td{
+            width: 60px;
+        }
+
+        table {border-collapse:separate;max-width: 850px; margin: 0 auto; width: 100%;}
+        .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td {line-height: 100%;}
+        .ExternalClass {width: 100%;}
+        @media screen and (max-width:500px){
+            .tab-td{
+                padding-left: 10px!important;
+            }
+            .tab-td a h4{
+                font-size: 14px!important;
+            }
+            .corner-td{
+                width: 20px!important;
+            }
+            .company-name-td h3{
+                font-size: 16px!important;
+            }
+            table.header-table{
+                padding-top: 8px!important;
+                padding-right: 0px!important;
+                padding-bottom: 24px!important;
+                padding-left: 0px!important;
+            }
+            .colored-card-td  h4{
+                font-size: 14px!important;
+            }
+            .colored-card-td  h2{
+                font-size: 20px!important;
+            }
+            .colored-card-td  a p{
+                font-size: 12px!important;
+                width: 143px!important;
+            }
+            .colored-card-td{
+                padding-top: 24px!important;
+                padding-right: 24px!important;
+                padding-bottom: 24px!important;
+                padding-left: 24px!important;
+            }
+            .colorless-card-td{
+                padding-top: 24px!important;
+                padding-right: 24px!important;
+                padding-bottom: 24px!important;
+                padding-left: 24px!important;
+            }
+            .colorless-card-td h3{
+                font-size: 18px!important;
+            }
+            .colorless-card-td p{
+                font-size: 14px!important;
+            }
+            .colorless-card-table{
+                margin-left: 0px!important;
+                margin-right: 0px!important;
+                margin-top: 24px!important;
+                margin-bottom: 24px!important;
+            }
+            .footer-td{
+                display: table-row!important;
+            }
+        }
+        @media screen and (max-width:600px) {
+            .footer-td{
+                display: table-row!important;
+            }
+        }
+        @media screen and (max-width:650px) {
+            .footer-table{
+                margin-left: 0px!important;
+                margin-right: 0px!important;
+                margin-top: 0px!important;
+                margin-bottom: 36px!important;
+            }
+        }
+    </style>
+</head>
+<body height="100%" width="100%">
+<table border="0" cellpadding="0" cellspacing="0" width="100%" bgcolor="E5E5E5" style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" height="36" class="header-table" style="padding-top: 36px ;padding-right: 0;padding-bottom: 36px;padding-left: 0;border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <td width="48" height="36" align="left"><img alt="Kerberos.io" width="36" height="36"  src="https://kerberos.io/images/email/kerberos.png"/></td>
+                    <td height="36" align="left" class="company-name-td">
+                        <h3  width="36" height="36" style=" font-family: Inter;
+                                        font-size: 20px;
+                                        font-style: normal;
+                                        font-weight: 600;
+                                        line-height: 24px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color: #262424;">Kerberos.io</h3>
+                    </td>
+                    <td  height="36" width="36" style="padding-left: 36px;" class="tab-td" align="right">
+                        <a style="text-decoration: none;color: none;" href={{tab1_href}}>
+                            <h4 style="font-family: Inter;
+                                            font-size: 16px;
+                                            font-style: normal;
+                                            font-weight: 500;
+                                            line-height: 36px;
+                                            mso-line-height-rule:exactly;
+                                            letter-spacing: 0em;
+                                            text-align: right;
+                                            color: #6D6666;">{{tab1_title}}</h4>
+                        </a>
+                    </td>
+                    <td  height="36" width="36" style="padding-left: 36px;" class="tab-td"  align="right" >
+                        <a style="text-decoration: none;color: none;" href={{tab2_href}}>
+                            <h4 style="font-family: Inter;
+                                            font-size: 16px;
+                                            font-style: normal;
+                                            font-weight: 500;
+                                            line-height: 36px;
+                                            mso-line-height-rule:exactly;
+                                            letter-spacing: 0em;
+                                            text-align: right;
+                                            color: #6D6666;">{{tab2_title}}</h4>
+                        </a>
+                    </td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%"  bgcolor="E5E5E5"  style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;" >
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <td class="colored-card-td" bgcolor="#57356B"  style="padding-left: 48px;padding-right: 48px;padding-top: 48px;padding-bottom: 48px;border-radius: 4px;background-color:#57356B;">
+                        <h2 style=" font-family: Inter;
+                                        font-size: 24px;
+                                        font-style: normal;
+                                        font-weight: 600;
+                                        line-height: 36px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color:#FFFFFF;
+                                        padding-top: 12px;
+                                        margin-bottom: 0;
+                                        padding-bottom: 0;
+                                        padding-left: 0;
+                                        padding-right: 0;">A case has been shared with you</h2>
+                        <h4 style="font-family: Inter;
+                                        font-size: 16px;
+                                        font-style: normal;
+                                        font-weight: 400;
+                                        line-height: 24px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color:#b09fb9;">{{user}} shared a case with you</h4>
+                    </td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%"  bgcolor="E5E5E5"  style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" class="colorless-card-table" style="margin-top: 36px;margin-bottom: 36px;margin-left: 0;margin-right: 0;border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;"  >
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <td  class="colorless-card-td" bgcolor="#FFFFFF" style="background-color:#FFFFFF;padding-top: 36px;padding-right: 43px;padding-bottom: 25px;padding-left: 43px;border-radius: 4px;">
+                        <h3 style=" font-family: Inter;
+                                        font-size: 20px;
+                                        font-style: normal;
+                                        font-weight: 600;
+                                        line-height: 36px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color: #262424;
+                                        width: 280px">Open the shared case</h3>
+                        <p style=" font-family: Inter;
+                                        font-size: 14px;
+                                        font-style: normal;
+                                        font-weight: 400;
+                                        line-height: 24px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color: #6D6666;
+                                        margin-top: 12px;">{{user}} has shared a case with you. Click the button below to open it. You'll be asked to request a one-time verification code from the share page itself.<br/><br/>This link will expire in {{expiry}}.</p>
+
+
+						<a style="text-decoration: none;color: none;" href="{{url}}">
+                            <p style="font-family: Inter;
+                                                font-size: 14px;
+                                                font-style: normal;
+                                                line-height: 24px;
+                                                mso-line-height-rule:exactly;
+                                                letter-spacing: 0em;
+                                                text-align: left;
+                                                color:#FFFFFF;
+                                                background-color: #84559F;
+                                                padding-top: 6px;
+                                                padding-bottom: 6px;
+                                                padding-right: 16px;
+                                                padding-left: 16px;
+                                                width: 130px;
+                                                border-radius: 4px;
+												text-align: center;
+                                                cursor: pointer;">Open case -></p>
+                        </a>
+					</td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%"  bgcolor="E5E5E5"  style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" class="footer-table" style="margin-top: 0;border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;"  >
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td style="vertical-align:top;display:table-row !important">
+                    <![endif]-->
+                    <td height="146" width="190" class="footer-td" style="margin-bottom: 12px;"  valign="top" align="left">
+                        <table style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <h4 style=" font-family: Inter;
+                                                        font-size: 16px;
+                                                        font-style: normal;
+                                                        font-weight: 600;
+                                                        line-height: 36px;
+                                                        mso-line-height-rule:exactly;
+                                                        letter-spacing: 0em;
+                                                        text-align: left;
+                                                        color:#6D6666;">Get in touch</h4>
+                                    <a style="text-decoration: none;color: none;" href="mailto:support@kerberos.io">
+                                        <p style=" font-family: Inter;
+                                                            font-size: 14px;
+                                                            font-style: normal;
+                                                            font-weight: 400;
+                                                            line-height: 16px;
+                                                            mso-line-height-rule:exactly;
+                                                            letter-spacing: 0em;
+                                                            text-align: left;
+                                                            color: #A69D9D;">support@kerberos.io</p>
+                                    </a>
+                                    <p style=" font-family: Inter;
+                                                            font-size: 14px;
+                                                            font-style: normal;
+                                                            font-weight: 400;
+                                    line-height: 16px;
+                                    mso-line-height-rule:exactly;
+                                    letter-spacing: 0em;
+                                    text-align: left;
+                                    color: #A69D9D;">9000 Ghent, BE</p>
+
+                                    <a style="text-decoration: none;color: none;" href="https://kerberos.io/">
+                                        <p style=" font-family: Inter;
+                                                            font-size: 14px;
+                                                            font-style: normal;
+                                                            font-weight: 400;
+                                                            line-height: 24px;
+                                                            mso-line-height-rule:exactly;
+                                                            letter-spacing: 0em;
+                                                            text-align: left;
+                                                            color: #A69D9D;">https://kerberos.io</p>
+                                    </a>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td style="vertical-align:top;display:table-row !important">
+                    <![endif]-->
+                    <td class="footer-td" style="border-radius: 4px;padding-left: 0;padding-right: 0;padding-top: 0;padding-bottom: 0; margin-bottom: 12px;"  valign="top" align="left">
+                        <table style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <h4 style=" font-family: Inter;
+                                                        font-size: 16px;
+                                                        font-style: normal;
+                                                        font-weight: 600;
+                                                        line-height: 36px;
+                                                        mso-line-height-rule:exactly;
+                                                        letter-spacing: 0em;
+                                                        text-align: left;
+                                                        color:#6D6666;">About Kerberos</h4>
+                                    <p style=" font-family: Inter;
+                                                        font-size: 14px;
+                                                        font-style: normal;
+                                                        font-weight: 400;
+                                                        line-height: 24px;
+                                                        mso-line-height-rule:exactly;
+                                                        letter-spacing: 0em;
+                                                        text-align: left;
+                                                        color: #A69D9D;">Welcome to the revolutionary video analytics and video management platform. Open, modular, and extensible for everyone, anywhere.</p>
+                                                        
+                                    
+                                    <p style="margin-top: 12px;">
+                                        <a href="https://twitter.com/kerberosio" style="text-decoration: none;color: none;">
+                                            <img width="24" height="24" alt="Twitter" src="https://kerberos.io/images/email/twitter.png"/>
+                                        </a>
+                                        <a href="https://reddit.com/r/kerberos_io" style="text-decoration: none;color: none;">
+                                            <img g width="24" height="24" alt="Reddit" src="https://kerberos.io/images/email/reddit.png"/>
+                                        </a>
+                                        <a href="https://www.youtube.com/channel/UCnd9q7iRNNw4W95eQwQuECA" style="text-decoration: none;color: none;">
+                                            <img g width="24" height="24" alt="Youtube" src="https://kerberos.io/images/email/youtube.png"/>
+                                        </a>
+                                        <a href="https://github.com/kerberos-io" style="text-decoration: none;color: none;">
+                                            <img g width="24" height="24" alt="Github" src="https://kerberos.io/images/email/github.png"/>
+                                        </a>
+                                    </p>                
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+            <table style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                <tbody>
+                    <tr style="height: 50px">
+                        <td></td>
+                    </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/charts/hub/custom-layout/templates/share_case.txt
+++ b/charts/hub/custom-layout/templates/share_case.txt
@@ -1,0 +1,21 @@
+Kerberos.io
+------------
+
+A case has been shared with you
+{{user}} shared a case with you
+
+Open the shared case
+{{user}} has shared a case with you. Open the link below to access it — you'll be asked to request a one-time verification code from the share page.
+{{url}}
+
+This link will expire in {{expiry}}.
+
+Get in touch
+------------
+support@kerberos.io
+9000 Ghent, BE
+https://kerberos.io
+
+About Kerberos
+------------
+Welcome to the revolutionary video analytics and video management platform. Open, modular, and extensible for everyone, anywhere.

--- a/charts/hub/custom-layout/templates/share_case_otp.html
+++ b/charts/hub/custom-layout/templates/share_case_otp.html
@@ -1,0 +1,425 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta
+            name="viewport"
+            content="width=device-width, initial-scale=1, minimum-scale=1, maximum-scale=1"
+    />
+    <meta name="description" content="Kerberos.io Mailing">
+    <style type="text/css">
+
+        @font-face {
+            font-family: 'Inter';
+            font-style:  normal;
+            font-weight: 400;
+            font-display: swap;
+            src: url("https://kerberos.io/dist/fonts/Inter-Regular.woff?v=/dist/fonts/Inter-Regular.woff2?v=3.183.18") format("woff2"),
+            url("https://kerberos.io/dist/fonts/Inter-Regular.woff?v=/dist/fonts/Inter-Regular.woff2?v=3.183.18") format("woff");
+        }
+
+        @font-face {
+            font-family: 'Inter';
+            font-style:  normal;
+            font-weight: 500;
+            font-display: swap;
+            src: url("https://kerberos.io/dist/fonts/Inter-Medium.woff2?v=3.18") format("woff2"),
+            url("https://kerberos.io/dist/fonts/Inter-Medium.woff?v=3.18") format("woff");
+        }
+
+        @font-face {
+            font-family: 'Inter';
+            font-style:  normal;
+            font-weight: 600;
+            font-display: swap;
+            src: url("https://kerberos.io/dist/fonts/Inter-SemiBold.woff2?v=3.18") format("woff2"),
+            url("https://kerberos.io/dist/fonts/Inter-SemiBold.woff?v=3.18") format("woff");
+        }
+
+        @font-face {
+            font-family: 'Inter var';
+            font-weight: 100 900;
+            font-display: swap;
+            font-style: normal;
+            font-named-instance: 'Regular';
+            src: url("https://kerberos.io/dist/fonts/Inter-roman.var.woff2?v=3.18") format("woff2");
+        }
+
+        body{
+            background: #E5E5E5;
+            margin-top:0;
+            margin-bottom: 0;
+            margin-right: 0;
+            margin-left: 0;
+            padding-top: 0;
+            padding-left: 0;
+            padding-right: 0;
+            padding-bottom: 0;
+            font-family: 'Inter';
+        }
+        a, a:hover, a:active {
+            color: #262424;
+            text-decoration: none;
+        }
+
+        .corner-td{
+            width: 60px;
+        }
+
+        table {border-collapse:separate;max-width: 850px; margin: 0 auto; width: 100%;}
+        .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td {line-height: 100%;}
+        .ExternalClass {width: 100%;}
+        @media screen and (max-width:500px){
+            .tab-td{
+                padding-left: 10px!important;
+            }
+            .tab-td a h4{
+                font-size: 14px!important;
+            }
+            .corner-td{
+                width: 20px!important;
+            }
+            .company-name-td h3{
+                font-size: 16px!important;
+            }
+            table.header-table{
+                padding-top: 8px!important;
+                padding-right: 0px!important;
+                padding-bottom: 24px!important;
+                padding-left: 0px!important;
+            }
+            .colored-card-td  h4{
+                font-size: 14px!important;
+            }
+            .colored-card-td  h2{
+                font-size: 20px!important;
+            }
+            .colored-card-td  a p{
+                font-size: 12px!important;
+                width: 143px!important;
+            }
+            .colored-card-td{
+                padding-top: 24px!important;
+                padding-right: 24px!important;
+                padding-bottom: 24px!important;
+                padding-left: 24px!important;
+            }
+            .colorless-card-td{
+                padding-top: 24px!important;
+                padding-right: 24px!important;
+                padding-bottom: 24px!important;
+                padding-left: 24px!important;
+            }
+            .colorless-card-td h3{
+                font-size: 18px!important;
+            }
+            .colorless-card-td p{
+                font-size: 14px!important;
+            }
+            .colorless-card-table{
+                margin-left: 0px!important;
+                margin-right: 0px!important;
+                margin-top: 24px!important;
+                margin-bottom: 24px!important;
+            }
+            .footer-td{
+                display: table-row!important;
+            }
+        }
+        @media screen and (max-width:600px) {
+            .footer-td{
+                display: table-row!important;
+            }
+        }
+        @media screen and (max-width:650px) {
+            .footer-table{
+                margin-left: 0px!important;
+                margin-right: 0px!important;
+                margin-top: 0px!important;
+                margin-bottom: 36px!important;
+            }
+        }
+    </style>
+</head>
+<body height="100%" width="100%">
+<table border="0" cellpadding="0" cellspacing="0" width="100%" bgcolor="E5E5E5" style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" height="36" class="header-table" style="padding-top: 36px ;padding-right: 0;padding-bottom: 36px;padding-left: 0;border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <td width="48" height="36" align="left"><img alt="Kerberos.io" width="36" height="36"  src="https://kerberos.io/images/email/kerberos.png"/></td>
+                    <td height="36" align="left" class="company-name-td">
+                        <h3  width="36" height="36" style=" font-family: Inter;
+                                        font-size: 20px;
+                                        font-style: normal;
+                                        font-weight: 600;
+                                        line-height: 24px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color: #262424;">Kerberos.io</h3>
+                    </td>
+                    <td  height="36" width="36" style="padding-left: 36px;" class="tab-td" align="right">
+                        <a style="text-decoration: none;color: none;" href={{tab1_href}}>
+                            <h4 style="font-family: Inter;
+                                            font-size: 16px;
+                                            font-style: normal;
+                                            font-weight: 500;
+                                            line-height: 36px;
+                                            mso-line-height-rule:exactly;
+                                            letter-spacing: 0em;
+                                            text-align: right;
+                                            color: #6D6666;">{{tab1_title}}</h4>
+                        </a>
+                    </td>
+                    <td  height="36" width="36" style="padding-left: 36px;" class="tab-td"  align="right" >
+                        <a style="text-decoration: none;color: none;" href={{tab2_href}}>
+                            <h4 style="font-family: Inter;
+                                            font-size: 16px;
+                                            font-style: normal;
+                                            font-weight: 500;
+                                            line-height: 36px;
+                                            mso-line-height-rule:exactly;
+                                            letter-spacing: 0em;
+                                            text-align: right;
+                                            color: #6D6666;">{{tab2_title}}</h4>
+                        </a>
+                    </td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%"  bgcolor="E5E5E5"  style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;" >
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <td class="colored-card-td" bgcolor="#57356B"  style="padding-left: 48px;padding-right: 48px;padding-top: 48px;padding-bottom: 48px;border-radius: 4px;background-color:#57356B;">
+                        <h2 style=" font-family: Inter;
+                                        font-size: 24px;
+                                        font-style: normal;
+                                        font-weight: 600;
+                                        line-height: 36px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color:#FFFFFF;
+                                        padding-top: 12px;
+                                        margin-bottom: 0;
+                                        padding-bottom: 0;
+                                        padding-left: 0;
+                                        padding-right: 0;">Verify your access</h2>
+                        <h4 style="font-family: Inter;
+                                        font-size: 16px;
+                                        font-style: normal;
+                                        font-weight: 400;
+                                        line-height: 24px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color:#b09fb9;">Use the code below to open the shared case</h4>
+                    </td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%"  bgcolor="E5E5E5"  style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" class="colorless-card-table" style="margin-top: 36px;margin-bottom: 36px;margin-left: 0;margin-right: 0;border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;"  >
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <td  class="colorless-card-td" bgcolor="#FFFFFF" style="background-color:#FFFFFF;padding-top: 36px;padding-right: 43px;padding-bottom: 25px;padding-left: 43px;border-radius: 4px;">
+                        <h3 style=" font-family: Inter;
+                                        font-size: 20px;
+                                        font-style: normal;
+                                        font-weight: 600;
+                                        line-height: 36px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color: #262424;
+                                        width: 280px">Your verification code</h3>
+                        <p style=" font-family: Inter;
+                                        font-size: 14px;
+                                        font-style: normal;
+                                        font-weight: 400;
+                                        line-height: 24px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color: #6D6666;
+                                        margin-top: 12px;">Enter the code below on the share page to access the case.</p>
+
+                        <p style="font-family: 'Courier New', Courier, monospace;
+                                        font-size: 32px;
+                                        font-style: normal;
+                                        font-weight: 600;
+                                        line-height: 40px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 8px;
+                                        text-align: center;
+                                        color:#262424;
+                                        background-color: #F2F0F4;
+                                        padding-top: 16px;
+                                        padding-bottom: 16px;
+                                        padding-right: 16px;
+                                        padding-left: 16px;
+                                        margin-top: 16px;
+                                        margin-bottom: 16px;
+                                        border-radius: 4px;">{{code}}</p>
+
+                        <p style=" font-family: Inter;
+                                        font-size: 14px;
+                                        font-style: normal;
+                                        font-weight: 400;
+                                        line-height: 24px;
+                                        mso-line-height-rule:exactly;
+                                        letter-spacing: 0em;
+                                        text-align: left;
+                                        color: #6D6666;">This code expires in {{expiry}}. If you didn't request this, you can safely ignore this email.</p>
+					</td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+<table border="0" cellpadding="0" cellspacing="0" width="100%"  bgcolor="E5E5E5"  style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+    <tr>
+        <td bgcolor="E5E5E5">
+            <table border="0" cellpadding="0" cellspacing="0" width="100%" class="footer-table" style="margin-top: 0;border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;"  >
+                <tbody>
+                <tr>
+                    <td class="corner-td" align="left"></td>
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td style="vertical-align:top;display:table-row !important">
+                    <![endif]-->
+                    <td height="146" width="190" class="footer-td" style="margin-bottom: 12px;"  valign="top" align="left">
+                        <table style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <h4 style=" font-family: Inter;
+                                                        font-size: 16px;
+                                                        font-style: normal;
+                                                        font-weight: 600;
+                                                        line-height: 36px;
+                                                        mso-line-height-rule:exactly;
+                                                        letter-spacing: 0em;
+                                                        text-align: left;
+                                                        color:#6D6666;">Get in touch</h4>
+                                    <a style="text-decoration: none;color: none;" href="mailto:support@kerberos.io">
+                                        <p style=" font-family: Inter;
+                                                            font-size: 14px;
+                                                            font-style: normal;
+                                                            font-weight: 400;
+                                                            line-height: 16px;
+                                                            mso-line-height-rule:exactly;
+                                                            letter-spacing: 0em;
+                                                            text-align: left;
+                                                            color: #A69D9D;">support@kerberos.io</p>
+                                    </a>
+                                    <p style=" font-family: Inter;
+                                                            font-size: 14px;
+                                                            font-style: normal;
+                                                            font-weight: 400;
+                                    line-height: 16px;
+                                    mso-line-height-rule:exactly;
+                                    letter-spacing: 0em;
+                                    text-align: left;
+                                    color: #A69D9D;">9000 Ghent, BE</p>
+
+                                    <a style="text-decoration: none;color: none;" href="https://kerberos.io/">
+                                        <p style=" font-family: Inter;
+                                                            font-size: 14px;
+                                                            font-style: normal;
+                                                            font-weight: 400;
+                                                            line-height: 24px;
+                                                            mso-line-height-rule:exactly;
+                                                            letter-spacing: 0em;
+                                                            text-align: left;
+                                                            color: #A69D9D;">https://kerberos.io</p>
+                                    </a>
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                    <!--[if mso | IE]>
+                    <table role="presentation" border="0" cellpadding="0" cellspacing="0"><tr><td style="vertical-align:top;display:table-row !important">
+                    <![endif]-->
+                    <td class="footer-td" style="border-radius: 4px;padding-left: 0;padding-right: 0;padding-top: 0;padding-bottom: 0; margin-bottom: 12px;"  valign="top" align="left">
+                        <table style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                            <tbody>
+                            <tr>
+                                <td>
+                                    <h4 style=" font-family: Inter;
+                                                        font-size: 16px;
+                                                        font-style: normal;
+                                                        font-weight: 600;
+                                                        line-height: 36px;
+                                                        mso-line-height-rule:exactly;
+                                                        letter-spacing: 0em;
+                                                        text-align: left;
+                                                        color:#6D6666;">About Kerberos</h4>
+                                    <p style=" font-family: Inter;
+                                                        font-size: 14px;
+                                                        font-style: normal;
+                                                        font-weight: 400;
+                                                        line-height: 24px;
+                                                        mso-line-height-rule:exactly;
+                                                        letter-spacing: 0em;
+                                                        text-align: left;
+                                                        color: #A69D9D;">Welcome to the revolutionary video analytics and video management platform. Open, modular, and extensible for everyone, anywhere.</p>
+                                                        
+                                    
+                                    <p style="margin-top: 12px;">
+                                        <a href="https://twitter.com/kerberosio" style="text-decoration: none;color: none;">
+                                            <img width="24" height="24" alt="Twitter" src="https://kerberos.io/images/email/twitter.png"/>
+                                        </a>
+                                        <a href="https://reddit.com/r/kerberos_io" style="text-decoration: none;color: none;">
+                                            <img g width="24" height="24" alt="Reddit" src="https://kerberos.io/images/email/reddit.png"/>
+                                        </a>
+                                        <a href="https://www.youtube.com/channel/UCnd9q7iRNNw4W95eQwQuECA" style="text-decoration: none;color: none;">
+                                            <img g width="24" height="24" alt="Youtube" src="https://kerberos.io/images/email/youtube.png"/>
+                                        </a>
+                                        <a href="https://github.com/kerberos-io" style="text-decoration: none;color: none;">
+                                            <img g width="24" height="24" alt="Github" src="https://kerberos.io/images/email/github.png"/>
+                                        </a>
+                                    </p>                
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+                    </td>
+                    <td class="corner-td" align="right"></td>
+                </tr>
+                </tbody>
+            </table>
+            <table style="border-collaps:collaps; mso-table-lspace:0pt; mso-table-rspace:0pt;">
+                <tbody>
+                    <tr style="height: 50px">
+                        <td></td>
+                    </tr>
+                </tbody>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>

--- a/charts/hub/custom-layout/templates/share_case_otp.txt
+++ b/charts/hub/custom-layout/templates/share_case_otp.txt
@@ -1,0 +1,21 @@
+Kerberos.io
+------------
+
+Verify your access
+Use the code below to open the shared case
+
+Your verification code
+{{code}}
+
+Enter this code on the share page to access the case. This code expires in {{expiry}}.
+If you didn't request this, you can safely ignore this email.
+
+Get in touch
+------------
+support@kerberos.io
+9000 Ghent, BE
+https://kerberos.io
+
+About Kerberos
+------------
+Welcome to the revolutionary video analytics and video management platform. Open, modular, and extensible for everyone, anywhere.

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -353,6 +353,10 @@ spec:
               value: "{{ .Values.email.templates.share }}"
             - name: SHARE_TITLE
               value: "{{ .Values.email.templates.shareTitle }}"
+            - name: CASE_SHARE_TEMPLATE
+              value: "{{ .Values.email.templates.caseShare }}"
+            - name: CASE_SHARE_TITLE
+              value: "{{ .Values.email.templates.caseShareTitle }}"
             - name: ASSIGN_TASK_TEMPLATE
               value: "{{ .Values.email.templates.assignTask }}"
             - name: ASSIGN_TASK_TITLE

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -357,6 +357,10 @@ spec:
               value: "{{ .Values.email.templates.caseShare }}"
             - name: CASE_SHARE_TITLE
               value: "{{ .Values.email.templates.caseShareTitle }}"
+            - name: CASE_SHARE_OTP_TEMPLATE
+              value: "{{ .Values.email.templates.caseShareOtp }}"
+            - name: CASE_SHARE_OTP_TITLE
+              value: "{{ .Values.email.templates.caseShareOtpTitle }}"
             - name: ASSIGN_TASK_TEMPLATE
               value: "{{ .Values.email.templates.assignTask }}"
             - name: ASSIGN_TASK_TITLE

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -1121,6 +1121,8 @@ email:
     shareTitle: "[Action] You received a recording from Kerberos Hub"
     caseShare: "share_case"
     caseShareTitle: "[Action] A case has been shared with you on Kerberos Hub"
+    caseShareOtp: "share_case_otp"
+    caseShareOtpTitle: "Your Kerberos Hub verification code"
     assignTask: "assign_task"
     assignTaskTitle: "[Action] You've been assigned to a task"
     detection: "detection"

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -1119,6 +1119,8 @@ email:
     forgotTitle: "Password reset Kerberos Hub. You forgot your password"
     share: "share"
     shareTitle: "[Action] You received a recording from Kerberos Hub"
+    caseShare: "share_case"
+    caseShareTitle: "[Action] A case has been shared with you on Kerberos Hub"
     assignTask: "assign_task"
     assignTaskTitle: "[Action] You've been assigned to a task"
     detection: "detection"

--- a/scripts/check-workflows-queue-consistency.sh
+++ b/scripts/check-workflows-queue-consistency.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Render the hub chart and assert that every deployment which carries the
+# workflows hand-off queue (the WORKFLOWS_QUEUE env var) resolves to the SAME,
+# non-empty value.
+#
+# Why: the analysis pipeline (pipe-analysis) publishes opened workflow runs to
+# WORKFLOWS_QUEUE, the workflows engine (hub-workflows) consumes it, and every
+# stage worker (hub-stage) routes its result back to it. All three templates
+# read the single key `kerberoshub.services.workflows.queue`. If a future edit
+# hardcodes a value, reads the wrong key, or drops the env on one of them, the
+# producer and consumer silently drift onto different queue names and messages
+# pile up with no consumer. This check fails the build before that can ship.
+#
+# Usage: scripts/check-workflows-queue-consistency.sh [chart-dir]
+#        (chart-dir defaults to charts/hub, relative to the repo root)
+
+set -euo pipefail
+
+CHART_DIR="${1:-charts/hub}"
+PROBE="drift-probe-queue-name"
+
+# Flags that force all three deployment kinds (analysis, engine and one stage
+# worker) to render, so the check actually has something to compare. anpr is a
+# stage/worker shipped in the chart's default values.
+RENDER_FLAGS=(
+  --set mode=all
+  --set kerberoshub.workflows.enabled=true
+  --set kerberoshub.workflows.stages.anpr.enabled=true
+  --set kerberoshub.services.anpr.enabled=true
+)
+
+# Read `helm template` output on stdin and print one WORKFLOWS_QUEUE value per
+# line. Matches the `- name: WORKFLOWS_QUEUE` env entry and captures the value
+# from the following `value:` line, skipping blank/comment lines in between.
+extract_workflows_queue() {
+  awk '
+    /^[[:space:]]*-[[:space:]]*name:[[:space:]]*WORKFLOWS_QUEUE[[:space:]]*$/ { want=1; next }
+    want==1 {
+      if ($0 ~ /^[[:space:]]*#/ || $0 ~ /^[[:space:]]*$/) next
+      v=$0
+      sub(/^[[:space:]]*value:[[:space:]]*/, "", v)
+      sub(/^"/, "", v); sub(/"[[:space:]]*$/, "", v)
+      sub(/[[:space:]]+$/, "", v)
+      print v
+      want=0
+    }
+  '
+}
+
+assert_all_equal() {
+  local expected="$1"; shift
+  local label="$1"; shift
+  local -a vals=("$@")
+
+  if [ "${#vals[@]}" -lt 2 ]; then
+    echo "FAIL (${label}): expected at least 2 WORKFLOWS_QUEUE values (analysis + engine), found ${#vals[@]}" >&2
+    return 1
+  fi
+
+  local v
+  for v in "${vals[@]}"; do
+    if [ -z "${v}" ]; then
+      echo "FAIL (${label}): a deployment rendered an empty WORKFLOWS_QUEUE value" >&2
+      return 1
+    fi
+    if [ "${v}" != "${expected}" ]; then
+      echo "FAIL (${label}): WORKFLOWS_QUEUE drift detected — expected '${expected}' but a deployment rendered '${v}'" >&2
+      printf '  rendered values: %s\n' "${vals[*]}" >&2
+      return 1
+    fi
+  done
+
+  echo "OK (${label}): ${#vals[@]} deployments all use WORKFLOWS_QUEUE='${expected}'"
+}
+
+echo "== Rendering ${CHART_DIR} with the chart's default workflows queue =="
+default_out="$(helm template hub "${CHART_DIR}" "${RENDER_FLAGS[@]}")"
+mapfile -t default_vals < <(printf '%s\n' "${default_out}" | extract_workflows_queue)
+default_queue="${default_vals[0]:-}"
+assert_all_equal "${default_queue}" "default values" "${default_vals[@]}" || exit 1
+
+echo "== Rendering ${CHART_DIR} with an overridden workflows queue (-> ${PROBE}) =="
+probe_out="$(helm template hub "${CHART_DIR}" "${RENDER_FLAGS[@]}" \
+  --set kerberoshub.services.workflows.queue="${PROBE}")"
+mapfile -t probe_vals < <(printf '%s\n' "${probe_out}" | extract_workflows_queue)
+assert_all_equal "${PROBE}" "override probe" "${probe_vals[@]}" || exit 1
+
+echo "All WORKFLOWS_QUEUE consistency checks passed."


### PR DESCRIPTION
## What

Wires the dedicated **case-share** email template into the hub chart so case-share invitations render with their own template instead of reusing the recording-share one.

- `charts/hub/templates/kerberos-hub/hub-api.yaml` — adds `CASE_SHARE_TEMPLATE` / `CASE_SHARE_TITLE` env (driven by `email.templates.caseShare` / `caseShareTitle`).
- `charts/hub/values.yaml` — adds `email.templates.caseShare` (`share_case`) and `caseShareTitle` defaults.
- `charts/hub/custom-layout/templates/share_case.html` + `share_case.txt` — white-label template (placeholders: `{{user}}`, `{{firstname}}`, `{{lastname}}`, `{{url}}`, `{{expiry}}`).

## Why

hub-api now calls `SendCaseShareEmail`, which selects the template/title via `CASE_SHARE_TEMPLATE`/`CASE_SHARE_TITLE`. This gives Helm deployments the white-label override. Default deployments already render the brand-neutral `share_case` template baked into `hub-pipeline-notification` v1.3.12.

## Related
- hub-pipeline-notification#100 (template) — released in v1.3.12
- hub-api#430 (SendCaseShareEmail) — merged
- deployment: companion PR adds the same wiring for kustomize deployments.