### PR TITLE
fix(hub): align disabled email template value with module name

### DIFF
--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -1126,7 +1126,7 @@ email:
     assignTask: "assign_task"
     assignTaskTitle: "[Action] You've been assigned to a task"
     detection: "detection"
-    disabled: "disabled"
+    disabled: "disable"
     highupload: "highupload"
     device: "device"
     alertTitle: "[Alert] Kerberos Hub detected something an event"


### PR DESCRIPTION
## What

Change `email.templates.disabled` from `"disabled"` to `"disable"`.

## Why

The notification module's `GetTemplate` only recognizes the template name `disable` (its embedded `disable` template / `disable.html` file). The chart wired `DISABLED_TEMPLATE` to the value `"disabled"`, so a consumer passing that env to `GetTemplate("disabled")` would fall through and return an empty body (only a literal `/mail/templates/disabled.html` override file would have resolved it).

This is a latent inconsistency — the only consumer currently lives in `hub-pipeline-monitor`'s archived `main.go.test` (not compiled), so no email is broken today — but setting the value to `disable` aligns it with the template/file/module naming so it resolves correctly if/when that path is re-enabled.

`highupload` already matches the module name, so no change is needed there.

## Scope

One-word value change, no template behaviour change for any active path.