### PR TITLE
fix(hub-stage): render valid YAML when multiple stage workers are enabled

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.121.0
+version: 0.121.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-pipeline/hub-stage.yaml
+++ b/charts/hub/templates/kerberos-pipeline/hub-stage.yaml
@@ -127,6 +127,6 @@ spec:
       protocol: TCP
   selector:
     app: hub-{{ $name }}
-{{- end }}
+{{ end -}}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
## Problem

Deploying `kerberos-hub` in production failed with the ArgoCD error:

> Failed last sync attempt ... `one or more synchronization tasks are not valid`

### Root cause

The generic stage-worker loop in `charts/hub/templates/kerberos-pipeline/hub-stage.yaml` renders a `Deployment` + `Service` per enabled worker under `kerberoshub.services.<name>`. The per-service `if` block closed with `{{- end }}`, whose **left-trim stripped the newline** after the Service's last line (`app: hub-<name>`).

- With **0 or 1** enabled stage worker the bug is latent.
- With **2+** enabled stage workers, the next worker's `---` document separator gets glued onto the previous Service's final line, e.g.:

```yaml
  selector:
    app: hub-loitering---        # <-- '---' glued, no newline
apiVersion: apps/v1
kind: Deployment
metadata:
  name: hub-objecttracking
```

This merges two resources into a single malformed document (duplicate `apiVersion`/`kind`/`metadata`/`spec`), which ArgoCD rejects.

In production this surfaced once `objecttracking` was enabled alongside `anpr` and `loitering` (3 stage workers → 2 glued boundaries: `anpr→loitering` and `loitering→objecttracking`).

## Fix

Emit a trailing newline before the next document separator by closing the per-service `if` with `{{ end -}}` instead of `{{- end }}`.

```diff
   selector:
     app: hub-{{ $name }}
-{{- end }}
+{{ end -}}
 {{- end }}
 {{- end }}
```

## Verification

Rendering the `hub` chart with the production values:

| | Before | After |
|---|---|---|
| Total documents | 56 | 58 |
| Malformed (Service+Deployment glued) | 2 | 0 |

- `helm lint charts/hub` → 0 failures
- `helm template` with prod values → 0 glued separators

Chart version bumped `0.121.0` → `0.121.1` so the fix can be published to `charts.kerberos.io`.

## Follow-ups (not in this PR)

- After publish, bump the `kerberos-hub` ArgoCD `targetRevision` to `0.121.1` in the gitops repo.
- Verify the `hub-anpr` **Service** actually exists in the cluster — the earlier `anpr→loitering` glue may have silently dropped it.
