### PR TITLE
feat(hub-api): inject WORKFLOW_DEFINITIONS env so config workflows surface in the API

### DIFF
--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -259,6 +259,15 @@ spec:
             - name: QUEUE_NAME
               value: "{{ .Values.queueName }}"
 
+            # Deployment-global workflow definitions (WORKFLOW_DEFINITIONS): the
+            # SAME set the workflows engine consumes, assembled from the enabled
+            # definitions under kerberoshub.workflows.definitions (see
+            # kerberos-pipeline/_workflows-helpers.tpl). hub-api reads these
+            # read-only to surface config workflows alongside the user workflows
+            # it stores in the database; the config workflows are never persisted.
+            - name: WORKFLOW_DEFINITIONS
+              value: {{ include "kerberoshub.workflows.workflowDefinitions" . | quote }}
+
             # Stripe for billing
             - name: STRIPE_KEY
               value: "{{ .Values.kerberoshub.api.stripe.privateKey }}"


### PR DESCRIPTION
## Problem

`hub-api` returns an empty config-workflow list from `GET /workflows` (e.g. filter `{surface:case,enabled:true}` → `[]`), so manual / on-demand config workflows (like `objecttracking-on-demand`) never appear in the API — even when the values and definitions are correct.

## Root cause

On `main`, `WORKFLOW_DEFINITIONS` is rendered **only for the workflows engine** (`kerberos-pipeline/hub-workflows.yaml`). `hub-api` never received it, so its `ConfigWorkflows()` reads an empty env and surfaces nothing. This is why the engine dispatches/routes correctly while the API listing is empty.

## Change

Add the `WORKFLOW_DEFINITIONS` env to `hub-api` using the same helper the engine uses (`kerberoshub.workflows.workflowDefinitions`). hub-api reads it read-only to surface config workflows alongside the DB/user workflows it stores; config workflows are never persisted.

## Verification

- `helm template hub charts/hub` now emits `WORKFLOW_DEFINITIONS` for the hub-api deployment (default values → `"[]"`; real deployments with enabled definitions populate it).
- No other templates changed.

## Deploy note

After merge + redeploy, the hub-api pod must roll to pick up the new env (its config-workflow cache is initialized once at process start). Verify with `printenv WORKFLOW_DEFINITIONS` in the hub-api pod.