### PR TITLE
Expose workflow stage queues to Hub API

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.124.0
+version: 0.125.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/templates/kerberos-hub/hub-api.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-api.yaml
@@ -267,6 +267,10 @@ spec:
             # it stores in the database; the config workflows are never persisted.
             - name: WORKFLOW_DEFINITIONS
               value: {{ include "kerberoshub.workflows.workflowDefinitions" . | quote }}
+            # Deployment service routing catalog used by API-owned embedded
+            # workflows (for example the one-stage case redaction modal flow).
+            - name: WORKFLOW_STAGE_QUEUES
+              value: {{ include "kerberoshub.workflows.stageQueues" . | quote }}
 
             # Stripe for billing
             - name: STRIPE_KEY

--- a/charts/hub/templates/kerberos-pipeline/_workflows-helpers.tpl
+++ b/charts/hub/templates/kerberos-pipeline/_workflows-helpers.tpl
@@ -46,3 +46,20 @@ Each enabled definition contributes one workflow object:
 {{- end -}}
 {{- $defs | toJson -}}
 {{- end -}}
+
+{{/*
+Expose the deployment's operation→queue catalog to API producers that seed
+embedded WorkflowRuns. Unlike WORKFLOW_DEFINITIONS this includes services that
+are enabled for internal flows but are absent from user-visible workflow
+definitions. The workflows engine remains authoritative for dispatch; producers
+use this only to embed the same queue on a synthetic stage.
+*/}}
+{{- define "kerberoshub.workflows.stageQueues" -}}
+{{- $queues := dict -}}
+{{- range $operation, $service := (.Values.kerberoshub.services | default dict) -}}
+{{- with $service.queue -}}
+{{- $_ := set $queues $operation . -}}
+{{- end -}}
+{{- end -}}
+{{- $queues | toJson -}}
+{{- end -}}


### PR DESCRIPTION
## Summary
- expose a generic operation-to-queue service catalog as `WORKFLOW_STAGE_QUEUES` on Hub API
- let API-owned embedded workflows route services that are not present in user-visible workflow definitions
- bump the Hub chart to `0.125.0`

## Validation
- `helm lint charts/hub`
- rendered production values map both API and redaction worker to `hub-redaction-queue`