### PR TITLE
docs(hub): add commented case-media-redaction workflow example

### DIFF
--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -680,6 +680,21 @@ kerberoshub:
       #      # (no condition ⇒ gate on the upstream's presence, not a value).
       #      needs:
       #        - operation: objecttracking
+      # EXAMPLE — the redaction editor's workflow. A manual trigger on the
+      # dedicated `redaction` surface binds this to the redaction editor's submit
+      # control (kept out of the case/media "Run workflow" list). On submit,
+      # hub-api runs THIS workflow's stages and injects the reviewed regions as
+      # the redaction stage's `media_edit` input, so no detector runs — the
+      # editor already supplied the regions. A single always-on redaction stage
+      # is the norm; deploy the redaction worker under services.redaction.
+      #case-media-redaction:
+      #  enabled: true
+      #  triggers:
+      #    - type: manual
+      #      surfaces: [redaction]
+      #  stages:
+      #    - operation: redaction
+      #      dispatch: always
   # Workflow deployments. Every workflows-subsystem Deployment's image/tag/
   # replicas/resources/queue lives here in a single, uniform shape:
   #   - `workflows` is the engine itself (the orchestrator). It is deployed


### PR DESCRIPTION
## What

Add a **commented** example of the redaction editor's workflow to `charts/hub/values.yaml`, alongside the existing `#tracking-workflow:` example.

```yaml
#case-media-redaction:
#  enabled: true
#  triggers:
#    - type: manual
#      surfaces: [redaction]
#  stages:
#    - operation: redaction
#      dispatch: always
```

## Why

The face-redaction editor (hub-frontend #696) resolves workflows bound to the `redaction` surface and runs the selected one; hub-api (#462) injects the reviewed regions as the redaction stage's `media_edit` input. This documents the expected shape so operators can enable it per-deployment.

Kept **commented** so the default `definitions: {}` stays empty — a live workflow here would enable it for every deployment. Real enablement lives in deployment values (e.g. gitops production #1475).

## Note

Only `charts/hub/values.yaml` is changed; no template/default behaviour changes.
