### PR TITLE
Add organisation frontend feature flags

### DIFF
--- a/charts/hub/README.md
+++ b/charts/hub/README.md
@@ -202,6 +202,8 @@ Below all configuration options and parameters are listed.
 | `kerberoshub.frontend.features.i18n.enabled` | Enable or disable the runtime language switcher in the front-end. When `"false"`, `defaultLanguage` is forced and users cannot change it. | `"true"` |
 | `kerberoshub.frontend.features.i18n.defaultLanguage` | Default language code used by the front-end (e.g. `en`, `nl`, `pl`, `tr`, `fr`, `sv`, `de`). | `"en"` |
 | `kerberoshub.frontend.features.workflows.enabled` | Enable or disable the workflows feature in the frontend. | `"false"` |
+| `kerberoshub.frontend.features.organisations.switcherEnabled` | Enable or disable the organisation dropdown and switching. The current organisation remains visible when disabled. | `"false"` |
+| `kerberoshub.frontend.features.organisations.creationEnabled` | Enable or disable organisation creation. Requires organisation switching to be enabled. | `"false"` |
 | `kerberoshub.frontend.features.map.tileUrlLight` | Tile URL used by the map in light mode. | `"https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png"` |
 | `kerberoshub.frontend.features.map.tileUrlDark` | Tile URL used by the map in dark mode. | `"https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"` |
 | `kerberoshub.frontend.features.map.attribution` | Attribution text displayed on the map tiles. | `"&copy; <a href='https://www.openstreetmap.org/copyright' target='_blank'>OpenStreetMap</a>"` |

--- a/charts/hub/templates/kerberos-hub/hub-frontend.yaml
+++ b/charts/hub/templates/kerberos-hub/hub-frontend.yaml
@@ -312,6 +312,10 @@ spec:
           value: "{{ .Values.kerberoshub.frontend.features.case.enabled }}"
         - name: FEATURE_WORKFLOWS_ENABLED
           value: "{{ .Values.kerberoshub.frontend.features.workflows.enabled }}"
+        - name: FEATURE_ORGANISATION_SWITCHER_ENABLED
+          value: "{{ .Values.kerberoshub.frontend.features.organisations.switcherEnabled }}"
+        - name: FEATURE_ORGANISATION_CREATION_ENABLED
+          value: "{{ .Values.kerberoshub.frontend.features.organisations.creationEnabled }}"
         - name: FEATURE_DARK_MODE
           value: "{{ .Values.kerberoshub.frontend.features.darkModeEnabled }}"
         - name: FEATURE_SPLASH_SCREEN_ENABLED

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -468,6 +468,10 @@ kerberoshub:
       # Workflows allow you to define automated processes and actions in the front-end.
       workflows:
         enabled: "false" # Enable or disable workflows feature 'true' or 'false'
+      # Organisation controls remain visible as a read-only current organisation when switching is disabled.
+      organisations:
+        switcherEnabled: "false" # Enable or disable organisation switching 'true' or 'false'
+        creationEnabled: "false" # Enable or disable organisation creation; requires switcherEnabled 'true' or 'false'
       # Map tile configuration  
       map:
         tileUrlLight: "https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png" # Map tile URL for light mode


### PR DESCRIPTION
## Summary
- add disabled-by-default Hub frontend values for organisation switching and creation
- map the values to `FEATURE_ORGANISATION_SWITCHER_ENABLED` and `FEATURE_ORGANISATION_CREATION_ENABLED`
- document both values and the creation dependency on switching

## Validation
- `helm lint charts/hub`
- rendered defaults resolve both environment variables to `"false"`
- rendered overrides resolve both environment variables to `"true"`