### PR TITLE
fix/allow-replicas-proxy-default-to-zero

### DIFF
--- a/charts/hub/Chart.yaml
+++ b/charts/hub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.127.0
+version: 0.128.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/hub/README.md
+++ b/charts/hub/README.md
@@ -296,7 +296,7 @@ Below all configuration options and parameters are listed.
 | `kerberoshub.reactivate.repository` | Container image repository for `kerberoshub.reactivate`. | `"uugai/hub-reactivatesubscriptions"` |
 | `kerberoshub.reactivate.pullPolicy` | Image pull policy for `kerberoshub.reactivate`. | `"IfNotPresent"` |
 | `kerberoshub.reactivate.tag` | Container image tag/version for `kerberoshub.reactivate`. | `"v1.0.2"` |
-| `kerberoshub.reactivate.replicas` | Number of replicas for `kerberoshub.reactivate`. | `1` |
+| `kerberoshub.reactivate.replicas` | Number of replicas for `kerberoshub.reactivate`. Set to `0` to disable. | `0` |
 | `kerberoshub.reactivate.logLevel` | Log verbosity level for `kerberoshub.reactivate`. | `"info"` |
 | `kerberoshub.reactivate.resources.requests.memory` | Memory request for `kerberoshub.reactivate`. | `"10Mi"` |
 | `kerberoshub.reactivate.resources.requests.cpu` | CPU request for `kerberoshub.reactivate`. | `"10m"` |
@@ -304,7 +304,7 @@ Below all configuration options and parameters are listed.
 | `kerberoshub.proxy.repository` | Container image repository for `kerberoshub.proxy`. | `"uugai/hub-proxy"` |
 | `kerberoshub.proxy.pullPolicy` | Image pull policy for `kerberoshub.proxy`. | `"IfNotPresent"` |
 | `kerberoshub.proxy.tag` | Container image tag/version for `kerberoshub.proxy`. | `"v1.0.0"` |
-| `kerberoshub.proxy.replicas` | Number of replicas for `kerberoshub.proxy`. | `1` |
+| `kerberoshub.proxy.replicas` | Number of replicas for `kerberoshub.proxy`. Set to `0` to disable. | `0` |
 | `kerberoshub.proxy.logLevel` | Log verbosity level for `kerberoshub.proxy`. | `"info"` |
 | `kerberoshub.proxy.resources.requests.memory` | Memory request for `kerberoshub.proxy`. | `"10Mi"` |
 | `kerberoshub.proxy.resources.requests.cpu` | CPU request for `kerberoshub.proxy`. | `"10m"` |

--- a/charts/hub/values.yaml
+++ b/charts/hub/values.yaml
@@ -806,7 +806,7 @@ kerberoshub:
     repository: uugai/hub-reactivatesubscriptions
     pullPolicy: IfNotPresent
     tag: "v1.0.2"
-    replicas: 1 # Number of pods for the service.
+    replicas: 0 # Number of pods for the service. Set to 0 to disable.
     topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
     # Optional extra volumes / volumeMounts for this deployment (empty = none).
     #volumes:
@@ -842,7 +842,7 @@ kerberoshub:
     repository: uugai/hub-proxy
     pullPolicy: IfNotPresent
     tag: "v1.0.0"
-    replicas: 1 # Number of pods for the service.
+    replicas: 0 # Number of pods for the service. Set to 0 to disable.
     topologySpreadConstraints: [] # Optional pod topology spread constraints (empty = none).
     # Optional extra volumes / volumeMounts for this deployment (empty = none).
     #volumes:


### PR DESCRIPTION
Default replicas for the hub proxy and reactivation subscriptions services are now set to 0, allowing them to be disabled unless explicitly enabled. This updates the chart metadata and docs to reflect the new default behavior.